### PR TITLE
Randomise operators and validators

### DIFF
--- a/src/components/NetworkFinder.js
+++ b/src/components/NetworkFinder.js
@@ -77,7 +77,7 @@ function NetworkFinder() {
           operators: state.network.getOperators(validators),
           loading: false
         })
-      }, error => setState({loading: false, error: error}))
+      }, error => setState({loading: false, error: 'Unable to connect right now, try again'}))
     }
   }, [state.network])
 

--- a/src/components/Validators.js
+++ b/src/components/Validators.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import _ from 'lodash'
 import FuzzySearch from 'fuzzy-search'
 
@@ -17,12 +17,33 @@ import {
 
 function Validators(props) {
   const [filter, setFilter] = useState()
+  const [orderedOperatorValidators, setOrderedOperatorValidators] = useState([])
+  const [orderedRegularValidators, setOrderedRegularValidators] = useState([])
+
+  useEffect(() => {
+    const ownerAddress = props.network && props.network.data.ownerAddress
+    setOrderedOperatorValidators(orderValidators(operatorValidators(), ownerAddress))
+    setOrderedRegularValidators(orderValidators(regularValidators()))
+  }, [props.operators, props.validators])
+
+  function orderValidators(validators, ownerAddress){
+    const random = _.shuffle(validators)
+    if(ownerAddress){
+      return _.sortBy(random, ({operator_address}) => operator_address === ownerAddress ? 0 : 1)
+    }
+    return random
+  }
+
+  function orderedRegularDelegations(){
+    const delegations = Object.values(_.omit(this.props.delegations, this.operatorAddresses()))
+    return _.shuffle(delegations)
+  }
 
   function operatorValidators(){
     return _.pick(props.validators, props.operators.map(el => el.address))
   }
 
-  function otherValidators(){
+  function regularValidators(){
     return _.omit(props.validators, props.operators.map(el => el.address))
   }
 
@@ -78,8 +99,8 @@ function Validators(props) {
     )
   }
 
-  const filteredOperators = Object.entries(filteredResults(operatorValidators()))
-  const filteredValidators = Object.entries(filteredResults(otherValidators()))
+  const filteredOperators = Object.entries(filteredResults(orderedOperatorValidators))
+  const filteredValidators = Object.entries(filteredResults(orderedRegularValidators))
 
   return (
     <>

--- a/src/networks.json
+++ b/src/networks.json
@@ -16,6 +16,7 @@
     "image": "https://raw.githubusercontent.com/osmosis-labs/assetlists/main/images/osmo.svg",
     "gasPrice": "0uosmo",
     "testAddress": "osmo1yxsmtnxdt6gxnaqrg0j0nudg7et2gqczed559y",
+    "ownerAddress": "osmovaloper1u5v0m74mql5nzfx2yh43s2tke4mvzghr6m2n5t",
     "operators": [
       {
         "address": "osmovaloper1u5v0m74mql5nzfx2yh43s2tke4mvzghr6m2n5t",
@@ -211,7 +212,14 @@
     ],
     "image": "https://raw.githubusercontent.com/osmosis-labs/assetlists/main/images/akt.svg",
     "testAddress": null,
+    "ownerAddress": "akashvaloper1xgnd8aach3vawsl38snpydkng2nv8a4kqgs8hf",
     "operators": [
+      {
+        "address": "akashvaloper1xgnd8aach3vawsl38snpydkng2nv8a4kqgs8hf",
+        "botAddress": "akash1yxsmtnxdt6gxnaqrg0j0nudg7et2gqczud2r2v",
+        "runTime": "21:00",
+        "minimumReward": 10000
+      },
       {
         "address": "akashvaloper1qwpnhmdlfj6gfyh0e29fjudh0ytfe5l7tjttul",
         "botAddress": "akash1yl54sf2ekqsc7y7r33267vhc546trx3ftzyns9",
@@ -247,6 +255,7 @@
     ],
     "image": "https://raw.githubusercontent.com/osmosis-labs/assetlists/main/images/huahua.png",
     "gasPrice": "0.025uhuahua",
+    "ownerAddress": "chihuahuavaloper19vwcee000fhazmpt4ultvnnkhfh23ppwxll8zz",
     "testAddress": "chihuahua1yxsmtnxdt6gxnaqrg0j0nudg7et2gqczjr22j5",
     "operators": [
       {


### PR DESCRIPTION
This will randomise the operator and validator list, but allow an `ownerAddress` for each network so the owner of the UI can keep their validator first in the list. I think this is fair overall.