### PR TITLE
Cosmos.directory proxy for CORS blocked networks

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: 'build'
+name: 'publish'
 
 on:
   push:

--- a/src/components/Delegations.js
+++ b/src/components/Delegations.js
@@ -119,7 +119,7 @@ class Delegations extends React.Component {
   }
 
   getTestGrant(){
-    this.props.restClient.getGrants(this.props.network.data.testaddress, this.props.address)
+    this.props.restClient.getGrants(this.props.network.data.testAddress, this.props.address)
       .then(
         (result) => { }, (error) => {
           if (error.response && error.response.status === 501) {

--- a/src/networks.json
+++ b/src/networks.json
@@ -191,7 +191,7 @@
     "prefix": "akash",
     "denom": "uakt",
     "restUrl": [
-      "http://rest.cosmos.directory/akash",
+      "https://rest.cosmos.directory/akash",
       "http://135.181.60.250:1317",
       "http://135.181.181.120:1518",
       "http://135.181.181.119:1518",
@@ -200,7 +200,7 @@
       "http://135.181.181.123:1518"
     ],
     "rpcUrl": [
-      "http://rpc.cosmos.directory/akash",
+      "https://rpc.cosmos.directory/akash",
       "http://135.181.60.250:26657",
       "http://rpc.akash.forbole.com:80",
       "http://akash-sentry01.skynetvalidators.com:26657",
@@ -346,12 +346,12 @@
     "prefix": "regen",
     "denom": "uregen",
     "restUrl": [
-      "http://rest.cosmos.directory/regen",
+      "https://rest.cosmos.directory/regen",
       "http://public-rpc.regen.vitwit.com:1317",
       "https://regen.stakesystems.io"
     ],
     "rpcUrl": [
-      "http://rpc.cosmos.directory/regen",
+      "https://rpc.cosmos.directory/regen",
       "http://public-rpc.regen.vitwit.com:26657",
       "https://regen.stakesystems.io:2053",
       "http://rpc.regen.forbole.com:80"
@@ -368,12 +368,12 @@
     "prefix": "terra",
     "denom": "uluna",
     "restUrl": [
-      "http://rest.cosmos.directory/terra",
+      "https://rest.cosmos.directory/terra",
       "http://64.227.72.101:1317",
       "https://blockdaemon-terra-lcd.api.bdnodes.net:1317"
     ],
     "rpcUrl": [
-      "http://rpc.cosmos.directory/terra",
+      "https://rpc.cosmos.directory/terra",
       "https://terra-rpc.easy2stake.com:443",
       "http://64.227.72.101:26657",
       "http://public-node.terra.dev:26657",

--- a/src/networks.json
+++ b/src/networks.json
@@ -191,6 +191,7 @@
     "prefix": "akash",
     "denom": "uakt",
     "restUrl": [
+      "http://rest.cosmos.directory/akash",
       "http://135.181.60.250:1317",
       "http://135.181.181.120:1518",
       "http://135.181.181.119:1518",
@@ -199,6 +200,7 @@
       "http://135.181.181.123:1518"
     ],
     "rpcUrl": [
+      "http://rpc.cosmos.directory/akash",
       "http://135.181.60.250:26657",
       "http://rpc.akash.forbole.com:80",
       "http://akash-sentry01.skynetvalidators.com:26657",
@@ -211,7 +213,7 @@
       "http://135.181.181.123:28957"
     ],
     "image": "https://raw.githubusercontent.com/osmosis-labs/assetlists/main/images/akt.svg",
-    "testAddress": null,
+    "testAddress": "akash1yxsmtnxdt6gxnaqrg0j0nudg7et2gqczud2r2v",
     "ownerAddress": "akashvaloper1xgnd8aach3vawsl38snpydkng2nv8a4kqgs8hf",
     "operators": [
       {
@@ -344,10 +346,12 @@
     "prefix": "regen",
     "denom": "uregen",
     "restUrl": [
+      "http://rest.cosmos.directory/regen",
       "http://public-rpc.regen.vitwit.com:1317",
       "https://regen.stakesystems.io"
     ],
     "rpcUrl": [
+      "http://rpc.cosmos.directory/regen",
       "http://public-rpc.regen.vitwit.com:26657",
       "https://regen.stakesystems.io:2053",
       "http://rpc.regen.forbole.com:80"
@@ -364,10 +368,12 @@
     "prefix": "terra",
     "denom": "uluna",
     "restUrl": [
+      "http://rest.cosmos.directory/terra",
       "http://64.227.72.101:1317",
       "https://blockdaemon-terra-lcd.api.bdnodes.net:1317"
     ],
     "rpcUrl": [
+      "http://rpc.cosmos.directory/terra",
       "https://terra-rpc.easy2stake.com:443",
       "http://64.227.72.101:26657",
       "http://public-node.terra.dev:26657",


### PR DESCRIPTION
Using a simple proxy server in front of the chain-registry API and RPC URLs for a couple of networks. Many of them have limited CORS config which means you can't access directly from the browser. Going via the proxy works great and allows the proxy to do the load balancing too. 

There is a repo for cosmos.directory but the current implementation is just to get these networks working for now. Watch this space 👀 