### PR TITLE
Add Frens Validator to Restake

### DIFF
--- a/src/networks.json
+++ b/src/networks.json
@@ -49,6 +49,12 @@
         "minimumReward": 10000
       },
       {
+        "address": "osmovaloper1ej2es5fjztqjcd4pwa0zyvaevtjd2y5w37wr9t",
+        "botAddress": "osmo1gvgcxwdk4j46gx3knhuackvqr2hta29zzygz95",
+        "runTime": "21:00",
+        "minimumReward": 5000
+      },
+      {
         "address": "osmovaloper1xwazl8ftks4gn00y5x3c47auquc62ssuh8af89",
         "botAddress": "osmo195mm9y35sekrjk73anw2az9lv9xs5mztjduk29",
         "runTime": "22:00",

--- a/src/networks.json
+++ b/src/networks.json
@@ -94,6 +94,12 @@
     "testAddress": "juno1yxsmtnxdt6gxnaqrg0j0nudg7et2gqcz8yyl52",
     "operators": [
       {
+        "address": "junovaloper1ej2es5fjztqjcd4pwa0zyvaevtjd2y5w2aqycm",
+        "botAddress": "juno1gvgcxwdk4j46gx3knhuackvqr2hta29zudcf56",
+        "runTime": "20:00",
+        "minimumReward": 10001
+      },
+      {
         "address": "junovaloper1x8u2ypdr35802tjyjqyxan8x85fzxe6sk0qmh8",
         "botAddress": "juno1r8egcurpwxftegr07gjv9gwffw4fk009a4v3ll",
         "runTime": "21:00",


### PR DESCRIPTION
First of all, thanks a lot for making this open source. I know the community has been asking for it and we are grateful somebody did it.

I added a separate bot address, since our compound bot works different than this one:
- ours does not require a delegation to us
- ours claims from all validators and delegates all rewards to us.

This is why I split them, otherwise if somebody uses restake to give us a grant, we would claim for other validators as well, which potentially was not intended. 
Since this can't be controlled with the AuthZ grant, this is the only way to keep them separate.