### PR TITLE
Autostaking script: Loop through pages of delegations 

### DIFF
--- a/scripts/autostake.mjs
+++ b/scripts/autostake.mjs
@@ -118,16 +118,12 @@ class Autostake {
   }
 
   getDelegations(client) {
-    return client.restClient.getValidatorDelegations(client.operator.address, 1_000)
-      .then(
-        (delegations) => {
-          return delegations
-        },
-        (error) => {
-          console.log("ERROR:", error)
-          process.exit()
-        }
-      )
+    return client.restClient.getAllValidatorDelegations(client.operator.address, 250, (batches, total) => {
+      console.log("...batch", batches.length)
+    }).catch(error => {
+      console.log("ERROR:", error)
+      process.exit()
+    })
   }
 
   getGrantValidators(client, delegatorAddress) {


### PR DESCRIPTION
Replaces the terrible 1k max delegations limit, and a bit kinder on public nodes. We can now obtain all delegations (@imperator-co) in a reliable way.

Will expand this to the UI where we lookup validators etc, but wanted to get the autostake script sorted out sooner rather than later.

Improves #44 
Resolves #21