### PR TITLE
fix: Sifchain prefix

### DIFF
--- a/src/networks.json
+++ b/src/networks.json
@@ -1144,7 +1144,7 @@
     "name": "sifchain",
     "prettyName": "Sifchain",
     "chainId": "sifchain-1",
-    "prefix": "sifchain",
+    "prefix": "sif",
     "denom": "rowan",
     "decimals": 18,
     "restUrl": [


### PR DESCRIPTION
The correct prefix for the Sifchain blockchain is "sif" not "sifchain".
You can verify this by checking the explorer (https://www.mintscan.io/sifchain) or Keplr.