### PR TITLE
Refactor QueryClient and improve status checking

### DIFF
--- a/scripts/autostake.mjs
+++ b/scripts/autostake.mjs
@@ -27,22 +27,21 @@ class Autostake {
     const calls = this.getNetworksData().map(data => {
       return async () => {
         if(networkName && data.name !== networkName) return
+        if(data.enabled === false) return
 
         let client
         try {
           client = await this.getClient(data)
         } catch (error) {
-          return console.log('Failed to connect')
+          return console.log('Failed to connect', error.message)
         }
 
-        if(!client.operator) return console.log('Not an operator')
-        if(!client.network.authzSupport) return console.log('No Authz support')
-        if(!data.overriden) console.log('You are using public nodes, script may fail with many delegations. Check the README to use your own')
-        if(!client.network.connected) return console.log('Could not connect to REST API')
-        if(!client.signingClient.connected) return console.log('Could not connect to RPC API')
+        if(!client) return console.log('Skipping')
 
         console.log('Using REST URL', client.network.restUrl)
-        console.log('Using RPC URL', client.signingClient.rpcUrl)
+        console.log('Using RPC URL', client.network.rpcUrl)
+
+        if(!data.overriden) console.log('You are using public nodes, script may fail with many delegations. Check the README to use your own')
 
         console.log('Running autostake')
         await this.checkBalance(client)
@@ -88,17 +87,19 @@ class Autostake {
 
     console.log(network.prettyName, 'bot address is', botAddress)
 
-    const client = await network.signingClient(wallet)
-    if(client.connected){
-      client.registry.register("/cosmos.authz.v1beta1.MsgExec", MsgExec)
-    }
+    const operatorData = data.operators.find(el => el.botAddress === botAddress)
 
-    let validators = {}
-    if(network.operators.find(el => el.botAddress === botAddress)){
-      validators = await network.getValidators()
-    }
+    if(!operatorData) return console.log('Not an operator')
+    if(!network.authzSupport) return console.log('No Authz support')
+    if(!network.rpcUrl) return console.log('Could not connect to RPC API')
+    if(!network.restUrl) return console.log('Could not connect to REST API')
+
+    const client = await network.signingClient(wallet)
+    client.registry.register("/cosmos.authz.v1beta1.MsgExec", MsgExec)
+
+    const validators = await network.getValidators()
     const operators = network.getOperators(validators)
-    const operator = operators.find(el => el.botAddress === botAddress)
+    const operator = network.getOperator(operators, botAddress)
 
     return{
       network: network,

--- a/scripts/autostake.mjs
+++ b/scripts/autostake.mjs
@@ -104,12 +104,12 @@ class Autostake {
       network: network,
       operator: operator,
       signingClient: client,
-      restClient: network.restClient
+      queryClient: network.queryClient
     }
   }
 
   checkBalance(client) {
-    return client.restClient.getBalance(client.operator.botAddress, client.network.denom)
+    return client.queryClient.getBalance(client.operator.botAddress, client.network.denom)
       .then(
         (balance) => {
           console.log("Bot balance is", balance.amount, balance.denom)
@@ -126,7 +126,7 @@ class Autostake {
   }
 
   getDelegations(client) {
-    return client.restClient.getAllValidatorDelegations(client.operator.address, 100, (pages) => {
+    return client.queryClient.getAllValidatorDelegations(client.operator.address, 100, (pages) => {
       console.log("...batch", pages.length)
     }).catch(error => {
       console.log("ERROR:", error.message || error)
@@ -152,7 +152,7 @@ class Autostake {
   }
 
   getGrantValidators(client, delegatorAddress) {
-    return client.restClient.getGrants(client.operator.botAddress, delegatorAddress)
+    return client.queryClient.getGrants(client.operator.botAddress, delegatorAddress)
       .then(
         (result) => {
           if(result.claimGrant && result.stakeGrant){
@@ -227,7 +227,7 @@ class Autostake {
   }
 
   totalRewards(client, address, validators){
-    return client.restClient.getRewards(address)
+    return client.queryClient.getRewards(address)
       .then(
         (rewards) => {
           const total = Object.values(rewards).reduce((sum, item) => {

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -2,7 +2,6 @@ import 'bootstrap/dist/css/bootstrap.min.css';
 import './App.css';
 import React from 'react'
 import _ from 'lodash'
-import SigningClient from '../utils/SigningClient.mjs'
 import AlertMessage from './AlertMessage'
 import NetworkSelect from './NetworkSelect'
 import Wallet from './Wallet'
@@ -75,7 +74,7 @@ class App extends React.Component {
 
     return this.setState({
       error: false,
-      restClient: network.restClient
+      queryClient: network.queryClient
     })
   }
 
@@ -100,12 +99,6 @@ class App extends React.Component {
       const offlineSigner = await window.getOfflineSignerAuto(chainId)
       const key = await window.keplr.getKey(chainId);
       const stargateClient = await this.props.network.signingClient(offlineSigner, key)
-      if(!stargateClient.connected){
-        this.setState({
-          error: 'Could not connect to any available RPC servers'
-        })
-        return
-      }
 
       const address = await stargateClient.getAddress()
 
@@ -135,7 +128,7 @@ class App extends React.Component {
       coinGeckoId: network.coinGeckoId
     }
     return window.keplr.experimentalSuggestChain({
-      rpc: network.rpcUrl[0],
+      rpc: network.rpcUrl,
       rest: network.restUrl,
       chainId: network.chainId,
       chainName: network.prettyName,
@@ -215,7 +208,7 @@ class App extends React.Component {
   }
 
   async getBalance() {
-    this.state.restClient.getBalance(this.state.address, this.props.network.denom)
+    this.state.queryClient.getBalance(this.state.address, this.props.network.denom)
       .then(
         (balance) => {
           this.setState({
@@ -299,7 +292,7 @@ class App extends React.Component {
                 validators={this.props.validators}
                 balance={this.state.balance}
                 getValidatorImage={this.getValidatorImage}
-                restClient={this.state.restClient}
+                queryClient={this.state.queryClient}
                 stargateClient={this.state.stargateClient} />
             </>
           }

--- a/src/components/Delegations.js
+++ b/src/components/Delegations.js
@@ -75,7 +75,7 @@ class Delegations extends React.Component {
   }
 
   getRewards(hideError) {
-    this.props.restClient.getRewards(this.props.address, this.props.network.denom)
+    this.props.queryClient.getRewards(this.props.address, this.props.network.denom)
       .then(
         (rewards) => {
           this.setState({ rewards: rewards });
@@ -93,7 +93,7 @@ class Delegations extends React.Component {
   getGrants() {
     this.props.operators.forEach(operator => {
       const {botAddress, address} = operator
-      this.props.restClient.getGrants(botAddress, this.props.address)
+      this.props.queryClient.getGrants(botAddress, this.props.address)
         .then(
           (result) => {
             let grantValidators
@@ -121,7 +121,7 @@ class Delegations extends React.Component {
   }
 
   getTestGrant(){
-    this.props.restClient.getGrants(this.props.network.testAddress, this.props.address)
+    this.props.queryClient.getGrants(this.props.network.testAddress, this.props.address)
       .then(
         (result) => { }, (error) => {
           if (error.response && error.response.status === 501) {

--- a/src/components/NetworkFinder.js
+++ b/src/components/NetworkFinder.js
@@ -77,7 +77,7 @@ function NetworkFinder() {
     if(state.error) return
 
     if(state.network && (!Object.keys(state.validators).length)){
-      if(!state.network.restClient.connected){
+      if(!state.network.connected){
         return setState({
           loading: false
         })

--- a/src/components/Wallet.js
+++ b/src/components/Wallet.js
@@ -52,7 +52,7 @@ class Wallet extends React.Component {
   }
 
   async getDelegations(hideError) {
-    this.props.restClient.getDelegations(this.props.address)
+    this.props.queryClient.getDelegations(this.props.address)
       .then(
         (delegations) => {
           this.setState({
@@ -145,7 +145,7 @@ class Wallet extends React.Component {
           validators={this.props.validators}
           getValidatorImage={this.props.getValidatorImage}
           delegations={this.state.delegations}
-          restClient={this.props.restClient}
+          queryClient={this.props.queryClient}
           stargateClient={this.props.stargateClient}
           getDelegations={this.getDelegations}
           onAddValidator={this.onAddValidator} />

--- a/src/utils/Network.mjs
+++ b/src/utils/Network.mjs
@@ -1,5 +1,5 @@
 import _ from 'lodash'
-import RestClient from './RestClient.mjs'
+import QueryClient from './QueryClient.mjs'
 import SigningClient from './SigningClient.mjs'
 import Operator from './Operator.mjs'
 import Chain from './Chain.mjs'
@@ -7,11 +7,11 @@ import Chain from './Chain.mjs'
 const Network = async (data) => {
 
   const chain = await Chain(data)
-  const restClient = await RestClient(chain.chainId, data.restUrl)
+  const queryClient = await QueryClient(chain.chainId, data.rpcUrl, data.restUrl)
 
   const signingClient = (wallet, key) => {
     const gasPrice = data.gasPrice || '0.0025' + chain.denom
-    return SigningClient(data.rpcUrl, chain.chainId, gasPrice, wallet, key)
+    return SigningClient(queryClient.rpcUrl, chain.chainId, gasPrice, wallet, key)
   }
 
   const getOperator = (operators, operatorAddress) => {
@@ -34,11 +34,11 @@ const Network = async (data) => {
   }
 
   const getValidators = () => {
-    return restClient.getAllValidators(150)
+    return queryClient.getAllValidators(150)
   }
 
   return {
-    connected: restClient.connected,
+    connected: queryClient.connected,
     name: data.name,
     prettyName: chain.prettyName,
     chainId: chain.chainId,
@@ -51,13 +51,13 @@ const Network = async (data) => {
     image: chain.image,
     coinGeckoId: chain.coinGeckoId,
     testAddress: data.testAddress,
-    restUrl: restClient.restUrl,
-    rpcUrl: data.rpcUrl,
+    restUrl: queryClient.restUrl,
+    rpcUrl: queryClient.rpcUrl,
     operators: data.operators,
     authzSupport: data.authzSupport,
     data,
     chain,
-    restClient,
+    queryClient,
     signingClient,
     getValidators,
     getOperators,

--- a/src/utils/SigningClient.mjs
+++ b/src/utils/SigningClient.mjs
@@ -12,9 +12,6 @@ import axios from 'axios'
 
 const SigningClient = async (rpcUrl, chainId, defaultGasPrice, signer, key) => {
 
-  const rpcUrls = Array.isArray(rpcUrl) ? rpcUrl : [rpcUrl]
-  rpcUrl = await findAvailableUrl(rpcUrls)
-
   const client = rpcUrl && await SigningStargateClient.connectWithSigner(
     rpcUrl,
     signer
@@ -71,18 +68,6 @@ const SigningClient = async (rpcUrl, chainId, defaultGasPrice, signer, key) => {
   const simulate = async (address, msgs, memo, modifier) => {
     const estimate = await client.simulate(address, msgs, memo)
     return (parseInt(estimate * (modifier || 1.5)))
-  }
-
-  function findAvailableUrl(urls){
-    return findAsync(urls, (url) => {
-      return axios.get(url + '/status?', {timeout: 1000})
-        .then(res => res.data)
-        .then(data => {
-          return data.result.node_info.network === chainId
-        }).catch(error => {
-          return false
-        })
-    })
   }
 
   return {


### PR DESCRIPTION
Some nodes block the /status endpoint which is what REStake was using to check node availability. Cosmos.directory checks the latest block endpoint instead so this PR matches that behaviour.

Also refactors RestClient -> QueryClient inline with #88, I'm sorry this will probably cause merge issues (@jemrickrioux on #87 too) but needed tidying up.