### PR TITLE
new function: getOperatorByBotAddress + fixes

### DIFF
--- a/scripts/autostake.mjs
+++ b/scripts/autostake.mjs
@@ -99,7 +99,7 @@ class Autostake {
 
     const validators = await network.getValidators()
     const operators = network.getOperators(validators)
-    const operator = network.getOperator(operators, botAddress)
+    const operator = network.getOperatorByBotAddress(operators, botAddress)
 
     return{
       network: network,

--- a/src/networks.json
+++ b/src/networks.json
@@ -1492,7 +1492,7 @@
         "address": "umeevaloper1gvt9l5tshr0fp8ksl2tuem584z69eyvt9m8yh6",
         "botAddress": "umee19pqrxrl6n0g0mky4y79hlfzchprmsp5jp3yygg",
         "runTime": "17:00",
-        "minimumReward": 10000,
+        "minimumReward": 10000
       }
     ],
     "authzSupport": true

--- a/src/utils/Network.mjs
+++ b/src/utils/Network.mjs
@@ -18,6 +18,10 @@ const Network = async (data) => {
     return operators.find(elem => elem.address === operatorAddress)
   }
 
+  const getOperatorByBotAddress = (operators, botAddress) => {
+    return operators.find(elem => elem.botAddress === botAddress)
+  }
+
   const getOperators = (validators) => {
     return sortOperators().map(operator => {
       const validator = validators[operator.address]
@@ -61,7 +65,8 @@ const Network = async (data) => {
     signingClient,
     getValidators,
     getOperators,
-    getOperator
+    getOperator,
+    getOperatorByBotAddress
   }
 }
 


### PR DESCRIPTION


* Querying for an operator was failing because `getOperator` in autostake was trying to query `getOperator` with `botAddress`. To work around this, I added a new function which queries operators by the `botAddress`

* JSON broken by a recent commit has been fixed