### PR TITLE
Autostake derivation paths and config

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,18 +209,33 @@ Create a `src/networks.local.json` file with JSON in the following format:
 ```json
 {
   "osmosis": {
-    "prettyName": "Foobar",
+    "prettyName": "Osmosis with Fees",
     "restUrl": [
       "https://rest.validator.com/osmosis"
     ],
     "rpcUrl": [
       "https://rpc.validator.com/osmosis"
-    ]
+    ],
+    "gasPrice": "0.001uosmo",
+    "autostake": {
+      "batchTxs": 69
+    }
+  },
+  "desmos": {
+    "prettyName": "Desmos 118",
+    "autostake": {
+      "correctSlip44": true
+    }
+  },
+  "cosmoshub": {
+    "enabled": false
   }
 }
 ```
 
-Any values you specify will override the `networks.json` file. Arrays will not be merged. The file is `.gitignore`'d so it won't affect updates.
+Any values you specify will override the `networks.json` file. These are examples, you can override as much or little as you need.
+
+Arrays will be replaced and not merged. The file is `.gitignore`'d so it won't affect upstream updates.
 
 ## Submiting your operator
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Right now, the REStake autostaking script uses the standard 118 derivation path 
 
 As there are existing operators using the 118 path, operators will need to opt in to the correct path when they want to upgrade. *New operators should use the correct path before they get grants*.
 
-The correct path can be set in one of two ways, using a [config override](#overriding-networks-config-locallyuse-your-own-node) file. You should use `"correctSlip44": true` if possible.
+The correct path can be set in one of two ways using a [config override](#overriding-networks-config-locallyuse-your-own-node) file. You should use `"correctSlip44": true` if possible.
 
 ```json
 {
@@ -46,11 +46,13 @@ The correct path can be set in one of two ways, using a [config override](#overr
     "prettyName": "Desmos 852",
     "autostake": {
       "correctSlip44": true, // Use the correct slip44 path from chain-registry
-      "slip44": 852 // Set a specific slip44 path
+      "slip44": 852 // Alternatively set a specific slip44 path
     }
   }
 }
 ```
+
+In the future, `correctSlip44` will become the default and you will need to set `slip44` explicitely if you want to use the 118 path.
 
 ### Setup the autostaking script and run daily
 

--- a/README.md
+++ b/README.md
@@ -34,13 +34,13 @@ You only need a single mnemonic for multiple Cosmos chains, and the script will 
 
 #### Derivation Paths (IMPORTANT)
 
-Right now, the REStake autostaking script uses the standard 118 derivation path by default. Some networks prefer a different path and apps like Keplr will honour this. *The address the autostake script uses might not match Keplr*.
+Right now, the REStake autostaking script uses the standard 118 derivation path by default. Some networks prefer a different path and apps like Keplr will honour this. **The address the autostake script uses might not match Keplr**.
 
-As there are existing operators using the 118 path, operators will need to opt in to the correct path when they want to upgrade. *New operators should use the correct path before they get grants*.
+As there are existing operators using the 118 path, operators will need to opt in to the correct path when they want to upgrade. **New operators should use the correct path before they get grants**.
 
 The correct path can be set in one of two ways using a [config override](#overriding-networks-config-locallyuse-your-own-node) file. You should use `"correctSlip44": true` if possible.
 
-```json
+```jsonc
 {
   "desmos": {
     "prettyName": "Desmos 852",

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Try it out at [restake.app](https://restake.app).
 
 ## How it works / Authz
 
-Authz is a new feature for Tendermint chains which lets you grant permission to another wallet to carry out certain transactions for you. These transactions are sent by the grantee on behalf of the granter, meaning the validator will send and pay for the TX, but actions will affect your wallet (such as claiming rewards). 
+Authz is a new feature for Tendermint chains which lets you grant permission to another wallet to carry out certain transactions for you. These transactions are sent by the grantee on behalf of the granter, meaning the validator will send and pay for the TX, but actions will affect your wallet (such as claiming rewards).
 
 REStake specifically lets you grant a validator permission to send `WithdrawDelegatorReward` and `Delegate` transactions for their validator only (note `WithdrawDelegatorReward` is technically not restricted to a single validator). The validator cannot send any other transaction types, and has no other access to your wallet. You authorize this using Keplr as normal.
 
@@ -30,11 +30,31 @@ Becoming an operator is extremely easy. You need to do three things:
 
 Generate a new hot wallet you will use to automatically carry out the staking transactions. The mnemonic will need to be provided to the script so **use a dedicated wallet and only keep enough funds for transaction fees**. The ONLY menmonic required here is for the hot wallet, do not put your validator operator mnemonic anywhere.
 
-You only need a single mnemonic for multiple Cosmos chains, and the script will check each network in the [networks.json](./src/networks.json) file for a matching bot address. 
+You only need a single mnemonic for multiple Cosmos chains, and the script will check each network in the [networks.json](./src/networks.json) file for a matching bot address.
+
+#### Derivation Paths (IMPORTANT)
+
+Right now, the REStake autostaking script uses the standard 118 derivation path by default. Some networks prefer a different path and apps like Keplr will honour this. *The address the autostake script uses might not match Keplr*.
+
+As there are existing operators using the 118 path, operators will need to opt in to the correct path when they want to upgrade. *New operators should use the correct path before they get grants*.
+
+The correct path can be set in one of two ways, using a [config override](#overriding-networks-config-locallyuse-your-own-node) file. You should use `"correctSlip44": true` if possible.
+
+```json
+{
+  "desmos": {
+    "prettyName": "Desmos 852",
+    "autostake": {
+      "correctSlip44": true, // Use the correct slip44 path from chain-registry
+      "slip44": 852 // Set a specific slip44 path
+    }
+  }
+}
+```
 
 ### Setup the autostaking script and run daily
 
-You can run the autostaking script using `docker-compose` or using `npm` directly. In both cases you will need to provide your mnemonic in a `MNEMONIC` environment variable. 
+You can run the autostaking script using `docker-compose` or using `npm` directly. In both cases you will need to provide your mnemonic in a `MNEMONIC` environment variable.
 
 Instructions are provided for Docker Compose and will be expanded later.
 
@@ -106,12 +126,12 @@ crontab -e
 
 Systemd-timer allow to run a one-off service with specified rules.
 
-##### Create a systemd unit file:
+##### Create a systemd unit file
 
 The unit file describe the application to run.  We define a dependency with the timer with the `Wants` statement.
 
 ```bash
-$ sudo vim /etc/systemd/system/restake.service
+sudo vim /etc/systemd/system/restake.service
 ```
 
 ```bash
@@ -130,12 +150,12 @@ ExecStart=/usr/bin/docker-compose run --rm app npm run autostake
 WantedBy=multi-user.target
 ```
 
-##### Create a systemd timer file:
+##### Create a systemd timer file
 
-The timer file defines the rules for running the restake service every day. All rules are described in the [systemd documentation](https://www.freedesktop.org/software/systemd/man/systemd.timer.html). 
+The timer file defines the rules for running the restake service every day. All rules are described in the [systemd documentation](https://www.freedesktop.org/software/systemd/man/systemd.timer.html).
 
 ```bash
-$ sudo vim /etc/systemd/system/restake.timer
+sudo vim /etc/systemd/system/restake.timer
 ```
 
 ```bash
@@ -153,9 +173,9 @@ WantedBy=timers.target
 ##### Enable and start everything
 
 ```bash
-$ systemctl enable restake.service
-$ systemctl enable restake.timer
-$ systemctl start restake.timer
+systemctl enable restake.service
+systemctl enable restake.timer
+systemctl start restake.timer
 ```
 
 ##### Check your timer
@@ -215,7 +235,7 @@ You now need to update the [networks.json](./src/networks.json) file at `./src/n
 },
 ```
 
-`address` is your validator's address, and `botAddress` is the address from your new hot wallet you generated earlier. 
+`address` is your validator's address, and `botAddress` is the address from your new hot wallet you generated earlier.
 
 `runTime` is the time *in UTC* that you intend to run your bot, and there are a few options. Pass a single time, e.g. `09:00` to specify a single run at 9am UTC. Use an array for multiple specified times, e.g. `["09:00", "21:00"]`. Use an interval string for multiple times per hour/day, e.g. `"every 15 minutes"`.
 
@@ -267,9 +287,9 @@ Alternative run from source using `docker-compose up` or `npm start`.
 
 ## Ethos
 
-The REStake UI is both validator and network agnostic. Any validator can be added as an operator and run this tool to provide an auto-compounding service to their delegators, but they can also run their own UI if they choose and adjust the branding to suit themselves. 
+The REStake UI is both validator and network agnostic. Any validator can be added as an operator and run this tool to provide an auto-compounding service to their delegators, but they can also run their own UI if they choose and adjust the branding to suit themselves.
 
-For this to work, we need a common source of chain information, and a common source of 'operator' information. Chain information is sourced from the [Chain Registry](https://github.com/cosmos/chain-registry), via an API provided by [cosmos.directory](https://registry.cosmos.directory). Operator information currently lives in the [networks.json](./src/networks.json) file in this repository. 
+For this to work, we need a common source of chain information, and a common source of 'operator' information. Chain information is sourced from the [Chain Registry](https://github.com/cosmos/chain-registry), via an API provided by [cosmos.directory](https://registry.cosmos.directory). Operator information currently lives in the [networks.json](./src/networks.json) file in this repository.
 
 If you fork this repository to provide your own UI, please keep up to date with the upstream to ensure you have the latest [networks.json](./src/networks.json) to include all operators. Some honesty is needed until we have a more decentralised solution.
 
@@ -280,4 +300,3 @@ The initial version of REStake was built quickly to take advantage of the new au
 ## ECO Stake 🌱
 
 ECO Stake is a climate positive validator, but we care about the Cosmos ecosystem too. We built REStake to make it easy for all validators to run an autocompounder with Authz, and it's one of many projects we work on in the ecosystem. [Delegate with us](https://ecostake.com) to support more projects like this.
-

--- a/scripts/autostake.mjs
+++ b/scripts/autostake.mjs
@@ -80,6 +80,9 @@ class Autostake {
     let network = await Network(data, true)
     let slip44
 
+    timeStamp('⚛')
+    timeStamp('Starting', network.prettyName)
+
     if(network.data.autostake?.correctSlip44){
       slip44 = network.slip44 || 118
     }else{
@@ -102,7 +105,12 @@ class Autostake {
     const accounts = await wallet.getAccounts()
     const botAddress = accounts[0].address
 
-    timeStamp(network.prettyName, 'bot address is', botAddress)
+    timeStamp('Bot address is', botAddress)
+
+    if (network.slip44 && network.slip44 !== slip44) {
+      timeStamp("!! You are not using the preferred derivation path !!")
+      timeStamp("!! You should switch to the correct path unless you have grants. Check the README !!")
+    } 
 
     const operatorData = data.operators.find(el => el.botAddress === botAddress)
 
@@ -121,8 +129,8 @@ class Autostake {
     const operator = network.getOperatorByBotAddress(operators, botAddress)
 
     return {
-      network: network,
-      operator: operator,
+      network,
+      operator,
       signingClient: client,
       queryClient: network.queryClient
     }
@@ -229,7 +237,9 @@ class Autostake {
   async autostake(client, messages) {
     let batchSize = client.network.data.autostake?.batchTxs || 50
     let batches = _.chunk(_.compact(messages), batchSize)
-    timeStamp('Sending', messages.length, 'messages in', batches.length, 'batches of', batchSize)
+    if(batches.length){
+      timeStamp('Sending', messages.length, 'messages in', batches.length, 'batches of', batchSize)
+    }
     let calls = batches.map((batch, index) => {
       return async () => {
         try {

--- a/scripts/autostake.mjs
+++ b/scripts/autostake.mjs
@@ -1,4 +1,5 @@
 import { DirectSecp256k1HdWallet } from "@cosmjs/proto-signing";
+import { Slip10RawIndex, pathToString } from "@cosmjs/crypto";
 import Network from '../src/utils/Network.mjs'
 import {timeStamp, mapSync, executeSync, overrideNetworks} from '../src/utils/Helpers.mjs'
 
@@ -77,9 +78,25 @@ class Autostake {
 
   async getClient(data) {
     let network = await Network(data, true)
+    let slip44
+
+    if(network.data.autostake?.correctSlip44){
+      slip44 = network.slip44 || 118
+    }else{
+      slip44 = network.data.autostake?.slip44 || 118
+    }
+    let hdPath = [
+      Slip10RawIndex.hardened(44),
+      Slip10RawIndex.hardened(slip44),
+      Slip10RawIndex.hardened(0),
+      Slip10RawIndex.normal(0),
+      Slip10RawIndex.normal(0),
+    ];
+    slip44 != 118 && timeStamp('Using HD Path', pathToString(hdPath))
 
     const wallet = await DirectSecp256k1HdWallet.fromMnemonic(this.mnemonic, {
-      prefix: network.prefix
+      prefix: network.prefix,
+      hdPaths: [hdPath]
     });
 
     const accounts = await wallet.getAccounts()

--- a/scripts/autostake.mjs
+++ b/scripts/autostake.mjs
@@ -42,32 +42,40 @@ class Autostake {
 
         if(!data.overriden) timeStamp('You are using public nodes, script may fail with many delegations. Check the README to use your own')
 
-        timeStamp('Running autostake')
-        await this.checkBalance(client)
-
-        timeStamp('Finding delegators...')
-        const addresses = await this.getDelegations(client).then(delegations => {
-          return delegations.map(delegation => {
-            if(delegation.balance.amount === 0) return
-
-            return delegation.delegation.delegator_address
-          })
-        })
-
-        timeStamp("Checking", addresses.length, "delegators for grants...")
-        let grantedAddresses = await this.getGrantedAddresses(client, addresses)
-
-        timeStamp("Found", grantedAddresses.length, "delegators with valid grants...")
-
-        let grantMessages = await this.getAutostakeMessages(client, grantedAddresses, [client.operator.address])
-        await this.autostake(client, grantMessages)
-        timeStamp(client.network.prettyName, "finished")
+        try {
+          await this.runNetwork(client)
+        } catch (error) {
+          return timeStamp('Autostake failed, skipping network', error.message)
+        }
       }
     })
     await executeSync(calls, 1)
   }
 
-  async getClient(data){
+  async runNetwork(client){
+    timeStamp('Running autostake')
+    await this.checkBalance(client)
+
+    timeStamp('Finding delegators...')
+    const addresses = await this.getDelegations(client).then(delegations => {
+      return delegations.map(delegation => {
+        if (delegation.balance.amount === 0) return
+
+        return delegation.delegation.delegator_address
+      })
+    })
+
+    timeStamp("Checking", addresses.length, "delegators for grants...")
+    let grantedAddresses = await this.getGrantedAddresses(client, addresses)
+
+    timeStamp("Found", grantedAddresses.length, "delegators with valid grants...")
+
+    let grantMessages = await this.getAutostakeMessages(client, grantedAddresses, [client.operator.address])
+    await this.autostake(client, grantMessages)
+    timeStamp(client.network.prettyName, "finished")
+  }
+
+  async getClient(data) {
     let network = await Network(data, true)
 
     const wallet = await DirectSecp256k1HdWallet.fromMnemonic(this.mnemonic, {
@@ -81,12 +89,12 @@ class Autostake {
 
     const operatorData = data.operators.find(el => el.botAddress === botAddress)
 
-    if(!operatorData) return timeStamp('Not an operator')
-    if(!network.authzSupport) return timeStamp('No Authz support')
+    if (!operatorData) return timeStamp('Not an operator')
+    if (!network.authzSupport) return timeStamp('No Authz support')
 
     network = await Network(data)
-    if(!network.rpcUrl) return timeStamp('Could not connect to RPC API')
-    if(!network.restUrl) return timeStamp('Could not connect to REST API')
+    if (!network.rpcUrl) return timeStamp('Could not connect to RPC API')
+    if (!network.restUrl) return timeStamp('Could not connect to REST API')
 
     const client = await network.signingClient(wallet)
     client.registry.register("/cosmos.authz.v1beta1.MsgExec", MsgExec)
@@ -95,7 +103,7 @@ class Autostake {
     const operators = network.getOperators(validators)
     const operator = network.getOperatorByBotAddress(operators, botAddress)
 
-    return{
+    return {
       network: network,
       operator: operator,
       signingClient: client,
@@ -108,7 +116,7 @@ class Autostake {
       .then(
         (balance) => {
           timeStamp("Bot balance is", balance.amount, balance.denom)
-          if(balance.amount < 1_000){
+          if (balance.amount < 1_000) {
             timeStamp('Bot balance is too low')
             process.exit()
           }
@@ -129,7 +137,7 @@ class Autostake {
     })
   }
 
-  async getGrantedAddresses(client, addresses){
+  async getGrantedAddresses(client, addresses) {
     let grantCalls = addresses.map(item => {
       return async () => {
         try {
@@ -147,12 +155,12 @@ class Autostake {
   }
 
   getGrantValidators(client, delegatorAddress) {
-    return client.queryClient.getGrants(client.operator.botAddress, delegatorAddress, {timeout: 5000})
+    return client.queryClient.getGrants(client.operator.botAddress, delegatorAddress, { timeout: 5000 })
       .then(
         (result) => {
-          if(result.claimGrant && result.stakeGrant){
+          if (result.claimGrant && result.stakeGrant) {
             const grantValidators = result.stakeGrant.authorization.allow_list.address
-            if(!grantValidators.includes(client.operator.address)){
+            if (!grantValidators.includes(client.operator.address)) {
               timeStamp(delegatorAddress, "Not autostaking for this validator, skipping")
               return
             }
@@ -166,7 +174,7 @@ class Autostake {
       )
   }
 
-  async getAutostakeMessages(client, addresses, validators){
+  async getAutostakeMessages(client, addresses, validators) {
     let calls = addresses.map(item => {
       return async () => {
         try {
@@ -182,12 +190,12 @@ class Autostake {
     return _.compact(messages.flat())
   }
 
-  async getAutostakeMessage(client, address, validators){
+  async getAutostakeMessage(client, address, validators) {
     const totalRewards = await this.totalRewards(client, address, validators)
 
     const perValidatorReward = parseInt(totalRewards / validators.length)
 
-    if(perValidatorReward < client.operator.data.minimumReward){
+    if (perValidatorReward < client.operator.data.minimumReward) {
       timeStamp(address, perValidatorReward, client.network.denom, 'reward is too low, skipping')
       return
     }
@@ -201,7 +209,7 @@ class Autostake {
     return this.buildExecMessage(client.operator.botAddress, messages)
   }
 
-  async autostake(client, messages){
+  async autostake(client, messages) {
     let batchSize = client.network.data.autostake?.batchTxs || 50
     let batches = _.chunk(_.compact(messages), batchSize)
     timeStamp('Sending', messages.length, 'messages in', batches.length, 'batches of', batchSize)
@@ -223,7 +231,7 @@ class Autostake {
     await executeSync(calls, 1)
   }
 
-  buildExecMessage(botAddress, messages){
+  buildExecMessage(botAddress, messages) {
     return {
       typeUrl: "/cosmos.authz.v1beta1.MsgExec",
       value: {
@@ -233,7 +241,7 @@ class Autostake {
     }
   }
 
-  buildRestakeMessage(address, validatorAddress, amount, denom){
+  buildRestakeMessage(address, validatorAddress, amount, denom) {
     return [{
       typeUrl: "/cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward",
       value: MsgWithdrawDelegatorReward.encode(MsgWithdrawDelegatorReward.fromPartial({
@@ -250,13 +258,13 @@ class Autostake {
     }]
   }
 
-  totalRewards(client, address, validators){
-    return client.queryClient.getRewards(address, {timeout: 5000})
+  totalRewards(client, address, validators) {
+    return client.queryClient.getRewards(address, { timeout: 5000 })
       .then(
         (rewards) => {
           const total = Object.values(rewards).reduce((sum, item) => {
             const reward = item.reward.find(el => el.denom === client.network.denom)
-            if(reward && validators.includes(item.validator_address)){
+            if (reward && validators.includes(item.validator_address)) {
               return sum + parseInt(reward.amount)
             }
             return sum
@@ -270,7 +278,7 @@ class Autostake {
       )
   }
 
-  getNetworksData(){
+  getNetworksData() {
     const networksData = fs.readFileSync('src/networks.json');
     const networks = JSON.parse(networksData);
     try {

--- a/scripts/autostake.mjs
+++ b/scripts/autostake.mjs
@@ -202,7 +202,7 @@ class Autostake {
   }
 
   async autostake(client, messages){
-    let batchSize = 50
+    let batchSize = client.network.data.autostake?.batchTxs || 50
     let batches = _.chunk(_.compact(messages), batchSize)
     timeStamp('Sending', messages.length, 'messages in', batches.length, 'batches of', batchSize)
     let calls = batches.map((batch, index) => {

--- a/src/networks.json
+++ b/src/networks.json
@@ -2344,6 +2344,9 @@
       "https://rpc.cosmos.directory/cerberus"
     ],
     "gasPrice": "0.025ucrbrus",
+    "autostake": {
+      "batchTxs": 100
+    },
     "testAddress": "cerberus1yxsmtnxdt6gxnaqrg0j0nudg7et2gqczd38dxa",
     "ownerAddress": "cerberusvaloper1tat2cy3f9djtq9z7ly262sqngcarvaktr0w78f",
     "operators": [


### PR DESCRIPTION
- Set the correct slip44 path with `autostake.correctSlip44: true` or `autostake.slip44: 852`
- Allow override of autostake batch TX size with `autostake.batchTxs: 69`. Default is 50.
- Handle chain connection failure and skip to the next network
- Show a warning in autostake output when using the 'wrong' derivation path
- Improve logging a bit more
- Improve example docs a bit more

Resolves #78 