### PR TITLE
Refresh balance after claim, delegate and redelegate

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -57,6 +57,7 @@ class App extends React.Component {
       this.connect()
     }
     if(this.props.network !== prevProps.network){
+      this.setState({ balance: undefined })
       this.connect()
       await this.setNetwork()
     }

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -31,6 +31,7 @@ class App extends React.Component {
     this.showNetworkSelect = this.showNetworkSelect.bind(this);
     this.getValidatorImage = this.getValidatorImage.bind(this);
     this.loadValidatorImages = this.loadValidatorImages.bind(this);
+    this.getBalance = this.getBalance.bind(this);
   }
 
   async componentDidMount() {
@@ -300,6 +301,7 @@ class App extends React.Component {
                 operators={this.props.operators}
                 validators={this.props.validators}
                 balance={this.state.balance}
+                onBalanceChange={this.getBalance}
                 getValidatorImage={this.getValidatorImage}
                 queryClient={this.state.queryClient}
                 stargateClient={this.state.stargateClient} />

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -301,7 +301,7 @@ class App extends React.Component {
                 operators={this.props.operators}
                 validators={this.props.validators}
                 balance={this.state.balance}
-                onBalanceChange={this.getBalance}
+                getBalance={this.getBalance}
                 getValidatorImage={this.getValidatorImage}
                 queryClient={this.state.queryClient}
                 stargateClient={this.state.stargateClient} />

--- a/src/components/Delegations.js
+++ b/src/components/Delegations.js
@@ -196,6 +196,7 @@ class Delegations extends React.Component {
 
   onClaimRewards() {
     this.setState({ claimLoading: false, validatorLoading: {}, error: null });
+    this.props.onBalanceChange();
     setTimeout(() => {
       this.props.getDelegations();
       this.getRewards();

--- a/src/components/Delegations.js
+++ b/src/components/Delegations.js
@@ -69,6 +69,7 @@ class Delegations extends React.Component {
 
   refreshInterval() {
     const interval = setInterval(() => {
+      this.props.getBalance();
       this.getRewards(true);
     }, 15_000);
     this.setState({ refreshInterval: interval });
@@ -196,8 +197,8 @@ class Delegations extends React.Component {
 
   onClaimRewards() {
     this.setState({ claimLoading: false, validatorLoading: {}, error: null });
-    this.props.onBalanceChange();
     setTimeout(() => {
+      this.props.getBalance();
       this.props.getDelegations();
       this.getRewards();
     }, 6_000);

--- a/src/components/Wallet.js
+++ b/src/components/Wallet.js
@@ -95,7 +95,7 @@ class Wallet extends React.Component {
           operators={this.props.operators}
           validators={this.props.validators}
           getValidatorImage={this.props.getValidatorImage}
-          onBalanceChange={this.props.onBalanceChange}
+          getBalance={this.props.getBalance}
           delegations={this.state.delegations}
           queryClient={this.props.queryClient}
           stargateClient={this.props.stargateClient}

--- a/src/components/Wallet.js
+++ b/src/components/Wallet.js
@@ -95,6 +95,7 @@ class Wallet extends React.Component {
           operators={this.props.operators}
           validators={this.props.validators}
           getValidatorImage={this.props.getValidatorImage}
+          onBalanceChange={this.props.onBalanceChange}
           delegations={this.state.delegations}
           queryClient={this.props.queryClient}
           stargateClient={this.props.stargateClient}


### PR DESCRIPTION
Send the getBalance function down as a "onBalanceChange" prop that can be triggered as necessary.

The current usage of that prop triggers it after claim, delegate and redelegate.

Issue ref: #124 