### PR TITLE
Fix minimum coin bug in delegation

### DIFF
--- a/src/components/Delegate.js
+++ b/src/components/Delegate.js
@@ -208,7 +208,7 @@ function Delegate(props) {
                     <td scope="row">REStake</td>
                     <td>
                       {!!operator() ? (
-                        <small>{operator().runTimesString()} (<Coins coins={minimumReward()} denom={props.network.denom} /> min)</small>
+                        <small>{operator().runTimesString()} (<Coins coins={minimumReward()} denom={props.network.denom} decimals={props.network.decimals} /> min)</small>
                       ) :
                         <TooltipIcon icon={<XCircle className="opacity-50 p-0" />} identifier={selectedValidator.operator_address} tooltip="This validator is not a REStake operator" />
                       }

--- a/src/networks.json
+++ b/src/networks.json
@@ -2206,8 +2206,8 @@
       {
         "address": "cheqdvaloper1m0f5mdkusqq24zhf8azjn2j5v2jqwqlt3ukrc0",
         "botAddress": "cheqd1ypntyymvjg90ntxwes3hxtmuvvh4fcr8w082sd",
-        "runTime": "21:00",
-        "minimumReward": 1000
+        "runTime": "every 1 hour",
+        "minimumReward": 100000000
       },
       {
         "address": "cheqdvaloper1qsp3a2qd6km9g0hczsac8279wcwmzmvzgvre8w",


### PR DESCRIPTION
Decimal data was not being passed onto the `Coins` component. As a result, coins would default to `decimals =6` even when a decimal was set in `networks.json`

Also tweaked my validator info