### PR TITLE
Fix manual restake by correctly setting up messages

### DIFF
--- a/src/components/Delegations.js
+++ b/src/components/Delegations.js
@@ -281,6 +281,26 @@ class Delegations extends React.Component {
     };
   }
 
+  validatorRewards(validators) {
+    if (!this.state.rewards) return;
+
+    const denom = this.props.network.denom;
+    const validatorRewards = Object.keys(this.state.rewards)
+        .map(validator => {
+          const validatorReward = this.state.rewards[validator];
+          const reward = validatorReward.reward.find((el) => el.denom === denom)
+          return {
+            validatorAddress: validator,
+            reward: reward ? parseInt(reward.amount) : undefined,
+          }
+        })
+        .filter(validatorReward => {
+          return validatorReward.reward && (validators === undefined || validators.includes(validatorReward.validatorAddress))
+        });
+
+    return validatorRewards;
+  }
+
   denomRewards(rewards) {
     return rewards.reward.find(
       (reward) => reward.denom === this.props.network.denom
@@ -462,8 +482,7 @@ class Delegations extends React.Component {
                       <ClaimRewards
                         network={this.props.network}
                         address={this.props.address}
-                        validators={[validatorAddress]}
-                        rewards={this.totalRewards([validatorAddress])}
+                        validatorRewards={this.validatorRewards([validatorAddress])}
                         stargateClient={this.props.stargateClient}
                         onClaimRewards={this.onClaimRewards}
                         setLoading={(loading) =>
@@ -475,8 +494,7 @@ class Delegations extends React.Component {
                         restake={true}
                         network={this.props.network}
                         address={this.props.address}
-                        validators={[validatorAddress]}
-                        rewards={this.totalRewards([validatorAddress])}
+                        validatorRewards={this.validatorRewards([validatorAddress])}
                         stargateClient={this.props.stargateClient}
                         onClaimRewards={this.onClaimRewards}
                         setLoading={(loading) =>
@@ -714,8 +732,7 @@ class Delegations extends React.Component {
                       <ClaimRewards
                         network={this.props.network}
                         address={this.props.address}
-                        validators={Object.keys(this.props.delegations)}
-                        rewards={this.totalRewards()}
+                        validatorRewards={this.validatorRewards()}
                         stargateClient={this.props.stargateClient}
                         onClaimRewards={this.onClaimRewards}
                         setLoading={this.setClaimLoading}
@@ -725,8 +742,7 @@ class Delegations extends React.Component {
                         restake={true}
                         network={this.props.network}
                         address={this.props.address}
-                        validators={Object.keys(this.props.delegations)}
-                        rewards={this.totalRewards()}
+                        validatorRewards={this.validatorRewards()}
                         stargateClient={this.props.stargateClient}
                         onClaimRewards={this.onClaimRewards}
                         setLoading={this.setClaimLoading}


### PR DESCRIPTION
This PR does the following:

- Fixes manual restaking which can fail because the simulated delegate message used totalReward for each delegation (so unless you had funds enough for that, it would fail)
- When restaking from multiple validators, it redelegates the same amount as is being claimed for each validator (instead of just spreading it out equally)
- Uses the simulated gas fees to proportinally take the fee from the rewards (not equally, but based on how much rewards are being claimed)

Issue ref: #340