### PR TITLE
fix: allow to properly parse Desmos profile accounts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,9 @@
       "dependencies": {
         "@bugsnag/js": "^7.16.1",
         "@bugsnag/plugin-react": "^7.16.1",
-        "@cosmjs/proto-signing": "^0.27.1",
-        "@cosmjs/stargate": "^0.27.1",
+        "@cosmjs/proto-signing": "^0.28.1",
+        "@cosmjs/stargate": "^0.28.1",
+        "@desmoslabs/desmjs": "^2.0.0-beta.4",
         "@testing-library/jest-dom": "^5.16.2",
         "@testing-library/react": "^12.1.3",
         "@testing-library/user-event": "^13.5.0",
@@ -468,37 +469,34 @@
       }
     },
     "node_modules/@cosmjs/amino": {
-      "version": "0.27.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.27.1.tgz",
-      "integrity": "sha512-w56ar/nK9+qlvWDpBPRmD0Blk2wfkkLqRi1COs1x7Ll1LF0AtkIBUjbRKplENLbNovK0T3h+w8bHiFm+GBGQOA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.28.1.tgz",
+      "integrity": "sha512-7CihIqU3YOE0dEa1e/dWDMetxmAjYa44P0trmU8cU5TU2JnCBPfjF4hZcTPfoZ4KXNKPQrqAWuLxy0YB6o/5/Q==",
       "dependencies": {
-        "@cosmjs/crypto": "0.27.1",
-        "@cosmjs/encoding": "0.27.1",
-        "@cosmjs/math": "0.27.1",
-        "@cosmjs/utils": "0.27.1"
+        "@cosmjs/crypto": "0.28.1",
+        "@cosmjs/encoding": "0.28.1",
+        "@cosmjs/math": "0.28.1",
+        "@cosmjs/utils": "0.28.1"
       }
     },
     "node_modules/@cosmjs/crypto": {
-      "version": "0.27.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.27.1.tgz",
-      "integrity": "sha512-vbcxwSt99tIYJg8Spp00wc3zx72qx+pY3ozGuBN8gAvySnagK9dQ/jHwtWQWdammmdD6oW+75WfIHZ+gNa+Ybg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.28.1.tgz",
+      "integrity": "sha512-QLgP+xvd3X4vNU9PPnEGc1PI5qctgg1o6ANivqHgiJdX2bFolsqCqFQDs1rvGf8GWLJ2eGwXZPX1c/QK0bT9+A==",
       "dependencies": {
-        "@cosmjs/encoding": "0.27.1",
-        "@cosmjs/math": "0.27.1",
-        "@cosmjs/utils": "0.27.1",
-        "bip39": "^3.0.2",
+        "@cosmjs/encoding": "0.28.1",
+        "@cosmjs/math": "0.28.1",
+        "@cosmjs/utils": "0.28.1",
+        "@noble/hashes": "^1",
         "bn.js": "^5.2.0",
         "elliptic": "^6.5.3",
-        "js-sha3": "^0.8.0",
-        "libsodium-wrappers": "^0.7.6",
-        "ripemd160": "^2.0.2",
-        "sha.js": "^2.4.11"
+        "libsodium-wrappers": "^0.7.6"
       }
     },
     "node_modules/@cosmjs/encoding": {
-      "version": "0.27.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.27.1.tgz",
-      "integrity": "sha512-rayLsA0ojHeniaRfWWcqSsrE/T1rl1gl0OXVNtXlPwLJifKBeLEefGbOUiAQaT0wgJ8VNGBazVtAZBpJidfDhw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.28.1.tgz",
+      "integrity": "sha512-FqKc+P5rBKq8hW2WHF6L8dmSJhy9mVBDhnJNCLUwyiKBywY9m4BZNTa0mPVQSXISx/c5DPbpJ5SChGL72qNgBw==",
       "dependencies": {
         "base64-js": "^1.3.0",
         "bech32": "^1.1.4",
@@ -506,59 +504,61 @@
       }
     },
     "node_modules/@cosmjs/json-rpc": {
-      "version": "0.27.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/json-rpc/-/json-rpc-0.27.1.tgz",
-      "integrity": "sha512-AKvsllGr6oN5kiroatIeIIxRdCFetLd8LCWV04RRNkoJ2OefDNb46VlWEQ+gI3ay5GgfVjB9qAcfvbJyrcEv+A==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/json-rpc/-/json-rpc-0.28.1.tgz",
+      "integrity": "sha512-yuOxhrE5ldJDcXhSbtdadAB5GBOGZkcDnZe+v70KcRf09qM81XPYiYfoMsxO9rb1QzThLlAbBx/kRebtzZPwDw==",
       "dependencies": {
-        "@cosmjs/stream": "0.27.1",
+        "@cosmjs/stream": "0.28.1",
         "xstream": "^11.14.0"
       }
     },
     "node_modules/@cosmjs/math": {
-      "version": "0.27.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.27.1.tgz",
-      "integrity": "sha512-cHWVjmfIjtRc7f80n7x+J5k8pe+vTVTQ0lA82tIxUgqUvgS6rogPP/TmGtTiZ4+NxWxd11DUISY6gVpr18/VNQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.28.1.tgz",
+      "integrity": "sha512-rF5q4BSwNBo0kNBi8asaoHsRx/TchJ/P4IlRjXY8UGCfKCkSRQEID3ffgE8naXf+BDn5x4cSC8da3xy/aCZpAA==",
       "dependencies": {
         "bn.js": "^5.2.0"
       }
     },
     "node_modules/@cosmjs/proto-signing": {
-      "version": "0.27.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.27.1.tgz",
-      "integrity": "sha512-t7/VvQivMdM1KgKWai/9ZCEcGFXJtr9Xo0hGcPLTn9wGkh9tmOsUXINYVMsf5D/jWIm1MDPbGCYfdb9V1Od4hw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.28.1.tgz",
+      "integrity": "sha512-dmBVV/b3x2mxwiEEdLFBpagr6R/X74R0AJLCxaKDwK4FpI4vSz84pOe5J6c9ffHHXnWp129M+pRBBE2S9tK0Cg==",
       "dependencies": {
-        "@cosmjs/amino": "0.27.1",
-        "@cosmjs/crypto": "0.27.1",
-        "@cosmjs/math": "0.27.1",
+        "@cosmjs/amino": "0.28.1",
+        "@cosmjs/crypto": "0.28.1",
+        "@cosmjs/encoding": "0.28.1",
+        "@cosmjs/math": "0.28.1",
+        "@cosmjs/utils": "0.28.1",
         "cosmjs-types": "^0.4.0",
         "long": "^4.0.0",
         "protobufjs": "~6.10.2"
       }
     },
     "node_modules/@cosmjs/socket": {
-      "version": "0.27.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/socket/-/socket-0.27.1.tgz",
-      "integrity": "sha512-bKCRsaSXh/TA7efxVCogzS2K3cgC40Ge2itFYmTfgpOE+++52FchCblVCsCYwMNDLS497RP4P0GbeC1VEBToMA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/socket/-/socket-0.28.1.tgz",
+      "integrity": "sha512-fFClGMOdBF3Jsti929AXoywsu6TtEKALxmwPvRYEsbrurLy9Ko28qoWdPFUvQw5WEy5rkzDq+3DKK5tbzsbQNA==",
       "dependencies": {
-        "@cosmjs/stream": "0.27.1",
+        "@cosmjs/stream": "0.28.1",
         "isomorphic-ws": "^4.0.1",
         "ws": "^7",
         "xstream": "^11.14.0"
       }
     },
     "node_modules/@cosmjs/stargate": {
-      "version": "0.27.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/stargate/-/stargate-0.27.1.tgz",
-      "integrity": "sha512-7hAIyNd6NbhQA51w9mPVyMYw515Hpj0o7SXMaqbc7nxs3hkJNMONQ9RakyMm0U/WeCd6ObcSaPEcdkqbfkc+mg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/stargate/-/stargate-0.28.1.tgz",
+      "integrity": "sha512-6mHHI2pkqb/khRTWRATODNieEv3PFhnUKgxkdiw39111oN35TTuSwxpT1c2le/VheoiaSZtBotDgL60wUP9LGA==",
       "dependencies": {
-        "@confio/ics23": "^0.6.3",
-        "@cosmjs/amino": "0.27.1",
-        "@cosmjs/encoding": "0.27.1",
-        "@cosmjs/math": "0.27.1",
-        "@cosmjs/proto-signing": "0.27.1",
-        "@cosmjs/stream": "0.27.1",
-        "@cosmjs/tendermint-rpc": "0.27.1",
-        "@cosmjs/utils": "0.27.1",
+        "@confio/ics23": "^0.6.8",
+        "@cosmjs/amino": "0.28.1",
+        "@cosmjs/encoding": "0.28.1",
+        "@cosmjs/math": "0.28.1",
+        "@cosmjs/proto-signing": "0.28.1",
+        "@cosmjs/stream": "0.28.1",
+        "@cosmjs/tendermint-rpc": "0.28.1",
+        "@cosmjs/utils": "0.28.1",
         "cosmjs-types": "^0.4.0",
         "long": "^4.0.0",
         "protobufjs": "~6.10.2",
@@ -566,24 +566,25 @@
       }
     },
     "node_modules/@cosmjs/stream": {
-      "version": "0.27.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/stream/-/stream-0.27.1.tgz",
-      "integrity": "sha512-cEyEAVfXEyuUpKYBeEJrOj8Dp/c+M6a0oGJHxvDdhP5gSsaeCPgQXrh7qZFBiUfu3Brmqd+e/bKZm+068l9bBw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/stream/-/stream-0.28.1.tgz",
+      "integrity": "sha512-lhgPI+vjpnwUOrLJADAA9YReMwbDCohIhuMhXiyXTnJfnUcitTh882LeRueyuynXW7zT1qjzZk1MgdumbDeXiA==",
       "dependencies": {
         "xstream": "^11.14.0"
       }
     },
     "node_modules/@cosmjs/tendermint-rpc": {
-      "version": "0.27.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/tendermint-rpc/-/tendermint-rpc-0.27.1.tgz",
-      "integrity": "sha512-eN1NyBYIiFutDNleEaTfvIJ3S3KA1gP45UHaLhSETm8KyiaUqg/b0Mj6sp7J3h4BhgwLq2zn/TDtIn0k5luedg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/tendermint-rpc/-/tendermint-rpc-0.28.1.tgz",
+      "integrity": "sha512-2Mt3Hd0Lp8BB6jnkiWr0U5oDRwOl3pueVFkCgv6XIUX8OKY48o97KOQrqW1BDAMYSL7QuXF7ULpvmRgfJqIxeA==",
       "dependencies": {
-        "@cosmjs/crypto": "0.27.1",
-        "@cosmjs/encoding": "0.27.1",
-        "@cosmjs/json-rpc": "0.27.1",
-        "@cosmjs/math": "0.27.1",
-        "@cosmjs/socket": "0.27.1",
-        "@cosmjs/stream": "0.27.1",
+        "@cosmjs/crypto": "0.28.1",
+        "@cosmjs/encoding": "0.28.1",
+        "@cosmjs/json-rpc": "0.28.1",
+        "@cosmjs/math": "0.28.1",
+        "@cosmjs/socket": "0.28.1",
+        "@cosmjs/stream": "0.28.1",
+        "@cosmjs/utils": "0.28.1",
         "axios": "^0.21.2",
         "readonly-date": "^1.0.0",
         "xstream": "^11.14.0"
@@ -598,9 +599,62 @@
       }
     },
     "node_modules/@cosmjs/utils": {
-      "version": "0.27.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.27.1.tgz",
-      "integrity": "sha512-VG7QPDiMUzVPxRdJahDV8PXxVdnuAHiIuG56hldV4yPnOz/si/DLNd7VAUUA5923b6jS1Hhev0Hr6AhEkcxBMg=="
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.28.1.tgz",
+      "integrity": "sha512-PhdsifctdpMUXeWQjbQiHeOCOhWtK/OXdEG3E2PvvYxlmWHNu1faio+u2gZU6PPjL+qgqlAu92sybwsw/TRa+w=="
+    },
+    "node_modules/@desmoslabs/desmjs": {
+      "version": "2.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@desmoslabs/desmjs/-/desmjs-2.0.0-beta.4.tgz",
+      "integrity": "sha512-Ywrb/fQt8fWKm3Xfcx5n9m1Xf/N+IzSIkvZgZ31v/79D5xX/4zN1cQkZO91eariKEsp70mUeB73vKeoXZs+ejw==",
+      "dependencies": {
+        "@cosmjs/amino": "^0.28.1",
+        "@cosmjs/crypto": "^0.28.1",
+        "@cosmjs/encoding": "^0.28.1",
+        "@cosmjs/math": "^0.28.1",
+        "@cosmjs/proto-signing": "^0.28.1",
+        "@cosmjs/stargate": "^0.28.1",
+        "@cosmjs/tendermint-rpc": "^0.28.1",
+        "@cosmjs/utils": "^0.28.1",
+        "@desmoslabs/desmjs-types": "2.0.0-beta.4",
+        "cosmjs-types": "^0.4.1",
+        "cosmos-wallet": "^1.1.0",
+        "long": "^4.0.0"
+      }
+    },
+    "node_modules/@desmoslabs/desmjs-types": {
+      "version": "2.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@desmoslabs/desmjs-types/-/desmjs-types-2.0.0-beta.4.tgz",
+      "integrity": "sha512-gBdVuUmyqAcirxdKzVXHtmQBS3QfzHglNYTeN0zgT/lH9AFnrpOMrbB8Z0hKiyUzkeJusTZo7pkX92gQ7n0vUA==",
+      "dependencies": {
+        "long": "^4.0.0",
+        "protobufjs": "^6.11.2"
+      }
+    },
+    "node_modules/@desmoslabs/desmjs-types/node_modules/protobufjs": {
+      "version": "6.11.2",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.2.tgz",
+      "integrity": "sha512-4BQJoPooKJl2G9j3XftkIXjoC9C0Av2NOrWmbLWT1vH32GcSUHjM0Arra6UfTsVyfMAuFzaLucXn1sadxJydAw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/long": "^4.0.1",
+        "@types/node": ">=13.7.0",
+        "long": "^4.0.0"
+      },
+      "bin": {
+        "pbjs": "bin/pbjs",
+        "pbts": "bin/pbts"
+      }
     },
     "node_modules/@emotion/babel-plugin": {
       "version": "11.7.2",
@@ -6172,6 +6226,81 @@
         "pbts": "bin/pbts"
       }
     },
+    "node_modules/cosmos-wallet": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/cosmos-wallet/-/cosmos-wallet-1.1.0.tgz",
+      "integrity": "sha512-jm5MFRYzvOCA/mhULObpaoE2Na0shBn3lrkv2GDedmRZfuoDvOa63WID4qMoIycteefjRKdxXf+26vDrgd79aQ==",
+      "dependencies": {
+        "@cosmjs/amino": "^0.25.4",
+        "@cosmjs/proto-signing": "^0.25.4"
+      }
+    },
+    "node_modules/cosmos-wallet/node_modules/@cosmjs/amino": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.25.6.tgz",
+      "integrity": "sha512-9dXN2W7LHjDtJUGNsQ9ok0DfxeN3ca/TXnxCR3Ikh/5YqBqxI8Gel1J9PQO9L6EheYyh045Wff4bsMaLjyEeqQ==",
+      "dependencies": {
+        "@cosmjs/crypto": "^0.25.6",
+        "@cosmjs/encoding": "^0.25.6",
+        "@cosmjs/math": "^0.25.6",
+        "@cosmjs/utils": "^0.25.6"
+      }
+    },
+    "node_modules/cosmos-wallet/node_modules/@cosmjs/crypto": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.25.6.tgz",
+      "integrity": "sha512-ec+YcQLrg2ibcxtNrh4FqQnG9kG9IE/Aik2NH6+OXQdFU/qFuBTxSFcKDgzzBOChwlkXwydllM9Jjbp+dgIzRw==",
+      "dependencies": {
+        "@cosmjs/encoding": "^0.25.6",
+        "@cosmjs/math": "^0.25.6",
+        "@cosmjs/utils": "^0.25.6",
+        "bip39": "^3.0.2",
+        "bn.js": "^4.11.8",
+        "elliptic": "^6.5.3",
+        "js-sha3": "^0.8.0",
+        "libsodium-wrappers": "^0.7.6",
+        "ripemd160": "^2.0.2",
+        "sha.js": "^2.4.11"
+      }
+    },
+    "node_modules/cosmos-wallet/node_modules/@cosmjs/encoding": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.25.6.tgz",
+      "integrity": "sha512-0imUOB8XkUstI216uznPaX1hqgvLQ2Xso3zJj5IV5oJuNlsfDj9nt/iQxXWbJuettc6gvrFfpf+Vw2vBZSZ75g==",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "bech32": "^1.1.4",
+        "readonly-date": "^1.0.0"
+      }
+    },
+    "node_modules/cosmos-wallet/node_modules/@cosmjs/math": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.25.6.tgz",
+      "integrity": "sha512-Fmyc9FJ8KMU34n7rdapMJrT/8rx5WhMw2F7WLBu7AVLcBh0yWsXIcMSJCoPHTOnMIiABjXsnrrwEaLrOOBfu6A==",
+      "dependencies": {
+        "bn.js": "^4.11.8"
+      }
+    },
+    "node_modules/cosmos-wallet/node_modules/@cosmjs/proto-signing": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.25.6.tgz",
+      "integrity": "sha512-JpQ+Vnv9s6i3x8f3Jo0lJZ3VMnj3R5sMgX+8ti1LtB7qEYRR85qbDrEG9hDGIKqJJabvrAuCHnO6hYi0vJEJHA==",
+      "dependencies": {
+        "@cosmjs/amino": "^0.25.6",
+        "long": "^4.0.0",
+        "protobufjs": "~6.10.2"
+      }
+    },
+    "node_modules/cosmos-wallet/node_modules/@cosmjs/utils": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.25.6.tgz",
+      "integrity": "sha512-ofOYiuxVKNo238vCPPlaDzqPXy2AQ/5/nashBo5rvPZJkxt9LciGfUEQWPCOb1BIJDNx2Dzu0z4XCf/dwzl0Dg=="
+    },
+    "node_modules/cosmos-wallet/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+    },
     "node_modules/create-ecdh": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
@@ -7879,14 +8008,14 @@
       }
     },
     "node_modules/libsodium": {
-      "version": "0.7.9",
-      "resolved": "https://registry.npmjs.org/libsodium/-/libsodium-0.7.9.tgz",
-      "integrity": "sha512-gfeADtR4D/CM0oRUviKBViMGXZDgnFdMKMzHsvBdqLBHd9ySi6EtYnmuhHVDDYgYpAO8eU8hEY+F8vIUAPh08A=="
+      "version": "0.7.10",
+      "resolved": "https://registry.npmjs.org/libsodium/-/libsodium-0.7.10.tgz",
+      "integrity": "sha512-eY+z7hDrDKxkAK+QKZVNv92A5KYkxfvIshtBJkmg5TSiCnYqZP3i9OO9whE79Pwgm4jGaoHgkM4ao/b9Cyu4zQ=="
     },
     "node_modules/libsodium-wrappers": {
-      "version": "0.7.9",
-      "resolved": "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.7.9.tgz",
-      "integrity": "sha512-9HaAeBGk1nKTRFRHkt7nzxqCvnkWTjn1pdjKgcUnZxj0FyOP4CnhgFhMdrFfgNsukijBGyBLpP2m2uKT1vuWhQ==",
+      "version": "0.7.10",
+      "resolved": "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.7.10.tgz",
+      "integrity": "sha512-pO3F1Q9NPLB/MWIhehim42b/Fwb30JNScCNh8TcQ/kIc+qGLQch8ag8wb0keK3EP5kbGakk1H8Wwo7v+36rNQg==",
       "dependencies": {
         "libsodium": "^0.7.0"
       }
@@ -10184,37 +10313,34 @@
       }
     },
     "@cosmjs/amino": {
-      "version": "0.27.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.27.1.tgz",
-      "integrity": "sha512-w56ar/nK9+qlvWDpBPRmD0Blk2wfkkLqRi1COs1x7Ll1LF0AtkIBUjbRKplENLbNovK0T3h+w8bHiFm+GBGQOA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.28.1.tgz",
+      "integrity": "sha512-7CihIqU3YOE0dEa1e/dWDMetxmAjYa44P0trmU8cU5TU2JnCBPfjF4hZcTPfoZ4KXNKPQrqAWuLxy0YB6o/5/Q==",
       "requires": {
-        "@cosmjs/crypto": "0.27.1",
-        "@cosmjs/encoding": "0.27.1",
-        "@cosmjs/math": "0.27.1",
-        "@cosmjs/utils": "0.27.1"
+        "@cosmjs/crypto": "0.28.1",
+        "@cosmjs/encoding": "0.28.1",
+        "@cosmjs/math": "0.28.1",
+        "@cosmjs/utils": "0.28.1"
       }
     },
     "@cosmjs/crypto": {
-      "version": "0.27.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.27.1.tgz",
-      "integrity": "sha512-vbcxwSt99tIYJg8Spp00wc3zx72qx+pY3ozGuBN8gAvySnagK9dQ/jHwtWQWdammmdD6oW+75WfIHZ+gNa+Ybg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.28.1.tgz",
+      "integrity": "sha512-QLgP+xvd3X4vNU9PPnEGc1PI5qctgg1o6ANivqHgiJdX2bFolsqCqFQDs1rvGf8GWLJ2eGwXZPX1c/QK0bT9+A==",
       "requires": {
-        "@cosmjs/encoding": "0.27.1",
-        "@cosmjs/math": "0.27.1",
-        "@cosmjs/utils": "0.27.1",
-        "bip39": "^3.0.2",
+        "@cosmjs/encoding": "0.28.1",
+        "@cosmjs/math": "0.28.1",
+        "@cosmjs/utils": "0.28.1",
+        "@noble/hashes": "^1",
         "bn.js": "^5.2.0",
         "elliptic": "^6.5.3",
-        "js-sha3": "^0.8.0",
-        "libsodium-wrappers": "^0.7.6",
-        "ripemd160": "^2.0.2",
-        "sha.js": "^2.4.11"
+        "libsodium-wrappers": "^0.7.6"
       }
     },
     "@cosmjs/encoding": {
-      "version": "0.27.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.27.1.tgz",
-      "integrity": "sha512-rayLsA0ojHeniaRfWWcqSsrE/T1rl1gl0OXVNtXlPwLJifKBeLEefGbOUiAQaT0wgJ8VNGBazVtAZBpJidfDhw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.28.1.tgz",
+      "integrity": "sha512-FqKc+P5rBKq8hW2WHF6L8dmSJhy9mVBDhnJNCLUwyiKBywY9m4BZNTa0mPVQSXISx/c5DPbpJ5SChGL72qNgBw==",
       "requires": {
         "base64-js": "^1.3.0",
         "bech32": "^1.1.4",
@@ -10222,59 +10348,61 @@
       }
     },
     "@cosmjs/json-rpc": {
-      "version": "0.27.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/json-rpc/-/json-rpc-0.27.1.tgz",
-      "integrity": "sha512-AKvsllGr6oN5kiroatIeIIxRdCFetLd8LCWV04RRNkoJ2OefDNb46VlWEQ+gI3ay5GgfVjB9qAcfvbJyrcEv+A==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/json-rpc/-/json-rpc-0.28.1.tgz",
+      "integrity": "sha512-yuOxhrE5ldJDcXhSbtdadAB5GBOGZkcDnZe+v70KcRf09qM81XPYiYfoMsxO9rb1QzThLlAbBx/kRebtzZPwDw==",
       "requires": {
-        "@cosmjs/stream": "0.27.1",
+        "@cosmjs/stream": "0.28.1",
         "xstream": "^11.14.0"
       }
     },
     "@cosmjs/math": {
-      "version": "0.27.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.27.1.tgz",
-      "integrity": "sha512-cHWVjmfIjtRc7f80n7x+J5k8pe+vTVTQ0lA82tIxUgqUvgS6rogPP/TmGtTiZ4+NxWxd11DUISY6gVpr18/VNQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.28.1.tgz",
+      "integrity": "sha512-rF5q4BSwNBo0kNBi8asaoHsRx/TchJ/P4IlRjXY8UGCfKCkSRQEID3ffgE8naXf+BDn5x4cSC8da3xy/aCZpAA==",
       "requires": {
         "bn.js": "^5.2.0"
       }
     },
     "@cosmjs/proto-signing": {
-      "version": "0.27.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.27.1.tgz",
-      "integrity": "sha512-t7/VvQivMdM1KgKWai/9ZCEcGFXJtr9Xo0hGcPLTn9wGkh9tmOsUXINYVMsf5D/jWIm1MDPbGCYfdb9V1Od4hw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.28.1.tgz",
+      "integrity": "sha512-dmBVV/b3x2mxwiEEdLFBpagr6R/X74R0AJLCxaKDwK4FpI4vSz84pOe5J6c9ffHHXnWp129M+pRBBE2S9tK0Cg==",
       "requires": {
-        "@cosmjs/amino": "0.27.1",
-        "@cosmjs/crypto": "0.27.1",
-        "@cosmjs/math": "0.27.1",
+        "@cosmjs/amino": "0.28.1",
+        "@cosmjs/crypto": "0.28.1",
+        "@cosmjs/encoding": "0.28.1",
+        "@cosmjs/math": "0.28.1",
+        "@cosmjs/utils": "0.28.1",
         "cosmjs-types": "^0.4.0",
         "long": "^4.0.0",
         "protobufjs": "~6.10.2"
       }
     },
     "@cosmjs/socket": {
-      "version": "0.27.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/socket/-/socket-0.27.1.tgz",
-      "integrity": "sha512-bKCRsaSXh/TA7efxVCogzS2K3cgC40Ge2itFYmTfgpOE+++52FchCblVCsCYwMNDLS497RP4P0GbeC1VEBToMA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/socket/-/socket-0.28.1.tgz",
+      "integrity": "sha512-fFClGMOdBF3Jsti929AXoywsu6TtEKALxmwPvRYEsbrurLy9Ko28qoWdPFUvQw5WEy5rkzDq+3DKK5tbzsbQNA==",
       "requires": {
-        "@cosmjs/stream": "0.27.1",
+        "@cosmjs/stream": "0.28.1",
         "isomorphic-ws": "^4.0.1",
         "ws": "^7",
         "xstream": "^11.14.0"
       }
     },
     "@cosmjs/stargate": {
-      "version": "0.27.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/stargate/-/stargate-0.27.1.tgz",
-      "integrity": "sha512-7hAIyNd6NbhQA51w9mPVyMYw515Hpj0o7SXMaqbc7nxs3hkJNMONQ9RakyMm0U/WeCd6ObcSaPEcdkqbfkc+mg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/stargate/-/stargate-0.28.1.tgz",
+      "integrity": "sha512-6mHHI2pkqb/khRTWRATODNieEv3PFhnUKgxkdiw39111oN35TTuSwxpT1c2le/VheoiaSZtBotDgL60wUP9LGA==",
       "requires": {
-        "@confio/ics23": "^0.6.3",
-        "@cosmjs/amino": "0.27.1",
-        "@cosmjs/encoding": "0.27.1",
-        "@cosmjs/math": "0.27.1",
-        "@cosmjs/proto-signing": "0.27.1",
-        "@cosmjs/stream": "0.27.1",
-        "@cosmjs/tendermint-rpc": "0.27.1",
-        "@cosmjs/utils": "0.27.1",
+        "@confio/ics23": "^0.6.8",
+        "@cosmjs/amino": "0.28.1",
+        "@cosmjs/encoding": "0.28.1",
+        "@cosmjs/math": "0.28.1",
+        "@cosmjs/proto-signing": "0.28.1",
+        "@cosmjs/stream": "0.28.1",
+        "@cosmjs/tendermint-rpc": "0.28.1",
+        "@cosmjs/utils": "0.28.1",
         "cosmjs-types": "^0.4.0",
         "long": "^4.0.0",
         "protobufjs": "~6.10.2",
@@ -10282,24 +10410,25 @@
       }
     },
     "@cosmjs/stream": {
-      "version": "0.27.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/stream/-/stream-0.27.1.tgz",
-      "integrity": "sha512-cEyEAVfXEyuUpKYBeEJrOj8Dp/c+M6a0oGJHxvDdhP5gSsaeCPgQXrh7qZFBiUfu3Brmqd+e/bKZm+068l9bBw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/stream/-/stream-0.28.1.tgz",
+      "integrity": "sha512-lhgPI+vjpnwUOrLJADAA9YReMwbDCohIhuMhXiyXTnJfnUcitTh882LeRueyuynXW7zT1qjzZk1MgdumbDeXiA==",
       "requires": {
         "xstream": "^11.14.0"
       }
     },
     "@cosmjs/tendermint-rpc": {
-      "version": "0.27.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/tendermint-rpc/-/tendermint-rpc-0.27.1.tgz",
-      "integrity": "sha512-eN1NyBYIiFutDNleEaTfvIJ3S3KA1gP45UHaLhSETm8KyiaUqg/b0Mj6sp7J3h4BhgwLq2zn/TDtIn0k5luedg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/tendermint-rpc/-/tendermint-rpc-0.28.1.tgz",
+      "integrity": "sha512-2Mt3Hd0Lp8BB6jnkiWr0U5oDRwOl3pueVFkCgv6XIUX8OKY48o97KOQrqW1BDAMYSL7QuXF7ULpvmRgfJqIxeA==",
       "requires": {
-        "@cosmjs/crypto": "0.27.1",
-        "@cosmjs/encoding": "0.27.1",
-        "@cosmjs/json-rpc": "0.27.1",
-        "@cosmjs/math": "0.27.1",
-        "@cosmjs/socket": "0.27.1",
-        "@cosmjs/stream": "0.27.1",
+        "@cosmjs/crypto": "0.28.1",
+        "@cosmjs/encoding": "0.28.1",
+        "@cosmjs/json-rpc": "0.28.1",
+        "@cosmjs/math": "0.28.1",
+        "@cosmjs/socket": "0.28.1",
+        "@cosmjs/stream": "0.28.1",
+        "@cosmjs/utils": "0.28.1",
         "axios": "^0.21.2",
         "readonly-date": "^1.0.0",
         "xstream": "^11.14.0"
@@ -10316,9 +10445,59 @@
       }
     },
     "@cosmjs/utils": {
-      "version": "0.27.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.27.1.tgz",
-      "integrity": "sha512-VG7QPDiMUzVPxRdJahDV8PXxVdnuAHiIuG56hldV4yPnOz/si/DLNd7VAUUA5923b6jS1Hhev0Hr6AhEkcxBMg=="
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.28.1.tgz",
+      "integrity": "sha512-PhdsifctdpMUXeWQjbQiHeOCOhWtK/OXdEG3E2PvvYxlmWHNu1faio+u2gZU6PPjL+qgqlAu92sybwsw/TRa+w=="
+    },
+    "@desmoslabs/desmjs": {
+      "version": "2.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@desmoslabs/desmjs/-/desmjs-2.0.0-beta.4.tgz",
+      "integrity": "sha512-Ywrb/fQt8fWKm3Xfcx5n9m1Xf/N+IzSIkvZgZ31v/79D5xX/4zN1cQkZO91eariKEsp70mUeB73vKeoXZs+ejw==",
+      "requires": {
+        "@cosmjs/amino": "^0.28.1",
+        "@cosmjs/crypto": "^0.28.1",
+        "@cosmjs/encoding": "^0.28.1",
+        "@cosmjs/math": "^0.28.1",
+        "@cosmjs/proto-signing": "^0.28.1",
+        "@cosmjs/stargate": "^0.28.1",
+        "@cosmjs/tendermint-rpc": "^0.28.1",
+        "@cosmjs/utils": "^0.28.1",
+        "@desmoslabs/desmjs-types": "2.0.0-beta.4",
+        "cosmjs-types": "^0.4.1",
+        "cosmos-wallet": "^1.1.0",
+        "long": "^4.0.0"
+      }
+    },
+    "@desmoslabs/desmjs-types": {
+      "version": "2.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@desmoslabs/desmjs-types/-/desmjs-types-2.0.0-beta.4.tgz",
+      "integrity": "sha512-gBdVuUmyqAcirxdKzVXHtmQBS3QfzHglNYTeN0zgT/lH9AFnrpOMrbB8Z0hKiyUzkeJusTZo7pkX92gQ7n0vUA==",
+      "requires": {
+        "long": "^4.0.0",
+        "protobufjs": "^6.11.2"
+      },
+      "dependencies": {
+        "protobufjs": {
+          "version": "6.11.2",
+          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.2.tgz",
+          "integrity": "sha512-4BQJoPooKJl2G9j3XftkIXjoC9C0Av2NOrWmbLWT1vH32GcSUHjM0Arra6UfTsVyfMAuFzaLucXn1sadxJydAw==",
+          "requires": {
+            "@protobufjs/aspromise": "^1.1.2",
+            "@protobufjs/base64": "^1.1.2",
+            "@protobufjs/codegen": "^2.0.4",
+            "@protobufjs/eventemitter": "^1.1.0",
+            "@protobufjs/fetch": "^1.1.0",
+            "@protobufjs/float": "^1.0.2",
+            "@protobufjs/inquire": "^1.1.0",
+            "@protobufjs/path": "^1.1.2",
+            "@protobufjs/pool": "^1.1.0",
+            "@protobufjs/utf8": "^1.1.0",
+            "@types/long": "^4.0.1",
+            "@types/node": ">=13.7.0",
+            "long": "^4.0.0"
+          }
+        }
+      }
     },
     "@emotion/babel-plugin": {
       "version": "11.7.2",
@@ -14260,6 +14439,83 @@
         }
       }
     },
+    "cosmos-wallet": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/cosmos-wallet/-/cosmos-wallet-1.1.0.tgz",
+      "integrity": "sha512-jm5MFRYzvOCA/mhULObpaoE2Na0shBn3lrkv2GDedmRZfuoDvOa63WID4qMoIycteefjRKdxXf+26vDrgd79aQ==",
+      "requires": {
+        "@cosmjs/amino": "^0.25.4",
+        "@cosmjs/proto-signing": "^0.25.4"
+      },
+      "dependencies": {
+        "@cosmjs/amino": {
+          "version": "0.25.6",
+          "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.25.6.tgz",
+          "integrity": "sha512-9dXN2W7LHjDtJUGNsQ9ok0DfxeN3ca/TXnxCR3Ikh/5YqBqxI8Gel1J9PQO9L6EheYyh045Wff4bsMaLjyEeqQ==",
+          "requires": {
+            "@cosmjs/crypto": "^0.25.6",
+            "@cosmjs/encoding": "^0.25.6",
+            "@cosmjs/math": "^0.25.6",
+            "@cosmjs/utils": "^0.25.6"
+          }
+        },
+        "@cosmjs/crypto": {
+          "version": "0.25.6",
+          "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.25.6.tgz",
+          "integrity": "sha512-ec+YcQLrg2ibcxtNrh4FqQnG9kG9IE/Aik2NH6+OXQdFU/qFuBTxSFcKDgzzBOChwlkXwydllM9Jjbp+dgIzRw==",
+          "requires": {
+            "@cosmjs/encoding": "^0.25.6",
+            "@cosmjs/math": "^0.25.6",
+            "@cosmjs/utils": "^0.25.6",
+            "bip39": "^3.0.2",
+            "bn.js": "^4.11.8",
+            "elliptic": "^6.5.3",
+            "js-sha3": "^0.8.0",
+            "libsodium-wrappers": "^0.7.6",
+            "ripemd160": "^2.0.2",
+            "sha.js": "^2.4.11"
+          }
+        },
+        "@cosmjs/encoding": {
+          "version": "0.25.6",
+          "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.25.6.tgz",
+          "integrity": "sha512-0imUOB8XkUstI216uznPaX1hqgvLQ2Xso3zJj5IV5oJuNlsfDj9nt/iQxXWbJuettc6gvrFfpf+Vw2vBZSZ75g==",
+          "requires": {
+            "base64-js": "^1.3.0",
+            "bech32": "^1.1.4",
+            "readonly-date": "^1.0.0"
+          }
+        },
+        "@cosmjs/math": {
+          "version": "0.25.6",
+          "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.25.6.tgz",
+          "integrity": "sha512-Fmyc9FJ8KMU34n7rdapMJrT/8rx5WhMw2F7WLBu7AVLcBh0yWsXIcMSJCoPHTOnMIiABjXsnrrwEaLrOOBfu6A==",
+          "requires": {
+            "bn.js": "^4.11.8"
+          }
+        },
+        "@cosmjs/proto-signing": {
+          "version": "0.25.6",
+          "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.25.6.tgz",
+          "integrity": "sha512-JpQ+Vnv9s6i3x8f3Jo0lJZ3VMnj3R5sMgX+8ti1LtB7qEYRR85qbDrEG9hDGIKqJJabvrAuCHnO6hYi0vJEJHA==",
+          "requires": {
+            "@cosmjs/amino": "^0.25.6",
+            "long": "^4.0.0",
+            "protobufjs": "~6.10.2"
+          }
+        },
+        "@cosmjs/utils": {
+          "version": "0.25.6",
+          "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.25.6.tgz",
+          "integrity": "sha512-ofOYiuxVKNo238vCPPlaDzqPXy2AQ/5/nashBo5rvPZJkxt9LciGfUEQWPCOb1BIJDNx2Dzu0z4XCf/dwzl0Dg=="
+        },
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+        }
+      }
+    },
     "create-ecdh": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
@@ -15618,14 +15874,14 @@
       }
     },
     "libsodium": {
-      "version": "0.7.9",
-      "resolved": "https://registry.npmjs.org/libsodium/-/libsodium-0.7.9.tgz",
-      "integrity": "sha512-gfeADtR4D/CM0oRUviKBViMGXZDgnFdMKMzHsvBdqLBHd9ySi6EtYnmuhHVDDYgYpAO8eU8hEY+F8vIUAPh08A=="
+      "version": "0.7.10",
+      "resolved": "https://registry.npmjs.org/libsodium/-/libsodium-0.7.10.tgz",
+      "integrity": "sha512-eY+z7hDrDKxkAK+QKZVNv92A5KYkxfvIshtBJkmg5TSiCnYqZP3i9OO9whE79Pwgm4jGaoHgkM4ao/b9Cyu4zQ=="
     },
     "libsodium-wrappers": {
-      "version": "0.7.9",
-      "resolved": "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.7.9.tgz",
-      "integrity": "sha512-9HaAeBGk1nKTRFRHkt7nzxqCvnkWTjn1pdjKgcUnZxj0FyOP4CnhgFhMdrFfgNsukijBGyBLpP2m2uKT1vuWhQ==",
+      "version": "0.7.10",
+      "resolved": "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.7.10.tgz",
+      "integrity": "sha512-pO3F1Q9NPLB/MWIhehim42b/Fwb30JNScCNh8TcQ/kIc+qGLQch8ag8wb0keK3EP5kbGakk1H8Wwo7v+36rNQg==",
       "requires": {
         "libsodium": "^0.7.0"
       }

--- a/package.json
+++ b/package.json
@@ -5,8 +5,9 @@
   "dependencies": {
     "@bugsnag/js": "^7.16.1",
     "@bugsnag/plugin-react": "^7.16.1",
-    "@cosmjs/proto-signing": "^0.27.1",
-    "@cosmjs/stargate": "^0.27.1",
+    "@cosmjs/proto-signing": "^0.28.1",
+    "@cosmjs/stargate": "^0.28.1",
+    "@desmoslabs/desmjs": "^2.0.0-beta.4",
     "@testing-library/jest-dom": "^5.16.2",
     "@testing-library/react": "^12.1.3",
     "@testing-library/user-event": "^13.5.0",

--- a/src/utils/SigningClient.mjs
+++ b/src/utils/SigningClient.mjs
@@ -7,12 +7,16 @@ import {
   assertIsDeliverTxSuccess,
   GasPrice
 } from '@cosmjs/stargate'
+import {profileFromAny} from "@desmoslabs/desmjs";
 
 const SigningClient = async (rpcUrl, chainId, defaultGasPrice, signer, key) => {
 
   const client = rpcUrl && await SigningStargateClient.connectWithSigner(
     rpcUrl,
-    signer
+    signer,
+    {
+      accountParser: profileFromAny,
+    }
   )
 
   const getAddress = async () => {


### PR DESCRIPTION
This PR adds the ability to parse non-standard Cosmos accounts. Particularly, using github.com/desmos-labs/desmjs it adds the support for Desmos Profile accounts. 

Closes: #334 