### PR TITLE
Add generic grant support in script

### DIFF
--- a/scripts/base.mjs
+++ b/scripts/base.mjs
@@ -197,7 +197,8 @@ export class Autostake {
       .then(
         (result) => {
           if (result.claimGrant && result.stakeGrant) {
-            if (result.stakeGrant.authorization['@type'] !== "/cosmos.authz.v1beta1.GenericAuthorization") {
+            if (result.stakeGrant.authorization['@type'] === "/cosmos.authz.v1beta1.GenericAuthorization") {
+              timeStamp(delegatorAddress, "Using GenericAuthorization, allowed")
               return [client.operator.address];
             }
 

--- a/scripts/base.mjs
+++ b/scripts/base.mjs
@@ -197,6 +197,10 @@ export class Autostake {
       .then(
         (result) => {
           if (result.claimGrant && result.stakeGrant) {
+            if (result.stakeGrant.authorization['@type'] !== "/cosmos.authz.v1beta1.GenericAuthorization") {
+              return [client.operator.address];
+            }
+
             const grantValidators = result.stakeGrant.authorization.allow_list.address
             if (!grantValidators.includes(client.operator.address)) {
               timeStamp(delegatorAddress, "Not autostaking for this validator, skipping")

--- a/src/utils/QueryClient.mjs
+++ b/src/utils/QueryClient.mjs
@@ -142,6 +142,17 @@ const QueryClient = async (chainId, rpcUrls, restUrls) => {
           } else {
             return false;
           }
+        }) || result.grants.find((el) => {
+          if (
+              el.authorization["@type"] ===
+              "/cosmos.authz.v1beta1.GenericAuthorization" &&
+              el.authorization.msg ===
+              "/cosmos.staking.v1beta1.MsgDelegate"
+          ) {
+            return Date.parse(el.expiration) > new Date();
+          } else {
+            return false;
+          }
         });
         return {
           claimGrant,

--- a/src/utils/QueryClient.mjs
+++ b/src/utils/QueryClient.mjs
@@ -136,24 +136,19 @@ const QueryClient = async (chainId, rpcUrls, restUrls) => {
         const stakeGrant = result.grants.find((el) => {
           if (
             el.authorization["@type"] ===
-            "/cosmos.staking.v1beta1.StakeAuthorization"
-          ) {
-            return Date.parse(el.expiration) > new Date();
-          } else {
-            return false;
-          }
-        }) || result.grants.find((el) => {
-          if (
+            "/cosmos.staking.v1beta1.StakeAuthorization" || (
+              // Handle GenericAuthorization for Ledger
               el.authorization["@type"] ===
               "/cosmos.authz.v1beta1.GenericAuthorization" &&
               el.authorization.msg ===
               "/cosmos.staking.v1beta1.MsgDelegate"
+            )
           ) {
             return Date.parse(el.expiration) > new Date();
           } else {
             return false;
           }
-        });
+        })
         return {
           claimGrant,
           stakeGrant,


### PR DESCRIPTION
This change is required to make the script pick up generic grant messages (which you need if you use ledger currently).

I am not a validator though, so I have only tested this from the point of view of the QueryClient. I would be very happy if a validator could test this before merging.