### PR TITLE
Handle large integers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "cosmjs-types": "^0.4.1",
         "dotenv": "^16.0.0",
         "fuzzy-search": "^3.2.1",
+        "mathjs": "^10.4.3",
         "moment": "^2.29.1",
         "parse-duration": "^1.0.2",
         "path": "^0.12.7",
@@ -343,9 +344,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.17.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.2.tgz",
-      "integrity": "sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==",
+      "version": "7.17.9",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.9.tgz",
+      "integrity": "sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==",
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
       },
@@ -6163,6 +6164,18 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true
     },
+    "node_modules/complex.js": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/complex.js/-/complex.js-2.1.0.tgz",
+      "integrity": "sha512-RdcrDz7YynXp/YXGwXIZ4MtmxXXniT5WmLFRX93cuXUX+0geWAqB8l1BoLXF+3BkzviVzHlpw27P9ow7MvlcmA==",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/infusion"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -6521,6 +6534,11 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.1.tgz",
+      "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ=="
+    },
     "node_modules/decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
@@ -6744,6 +6762,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/escape-latex": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/escape-latex/-/escape-latex-1.2.0.tgz",
+      "integrity": "sha512-nV5aVWW1K0wEiUIEdZ4erkGGH8mDxGyxSeqPzRNtWP7ataw+/olFObw7hujFWlVjNsaDFw5VZ5NzVSIqRgfTiw=="
     },
     "node_modules/escape-string-regexp": {
       "version": "1.0.5",
@@ -7240,6 +7263,18 @@
         "node": ">= 0.12"
       }
     },
+    "node_modules/fraction.js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.2.0.tgz",
+      "integrity": "sha512-MhLuK+2gUcnZe8ZHlaaINnQLl0xRIGRfcGk2yl8xoQAfHrSsL3rYu6FCmBdkdbhc9EPlwyGHewaRsvwRMJtAlA==",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/infusion"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -7704,6 +7739,11 @@
       "optional": true,
       "peer": true
     },
+    "node_modules/javascript-natural-sort": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
+      "integrity": "sha1-+eIwPUUH9tdDVac2ZNFED7Wg71k="
+    },
     "node_modules/jest-diff": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.5.1.tgz",
@@ -8110,6 +8150,28 @@
       "integrity": "sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=",
       "bin": {
         "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/mathjs": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-10.4.3.tgz",
+      "integrity": "sha512-C50lWorCOplBec9Ik5fzhHuOx4G4+mtdz3r1G2I1/r8yj+CpYFXLXNqTdg59oKmIF1tKcIzpxlC4s2dGL7f3pg==",
+      "dependencies": {
+        "@babel/runtime": "^7.17.8",
+        "complex.js": "^2.1.0",
+        "decimal.js": "^10.3.1",
+        "escape-latex": "^1.2.0",
+        "fraction.js": "^4.2.0",
+        "javascript-natural-sort": "^0.7.1",
+        "seedrandom": "^3.0.5",
+        "tiny-emitter": "^2.1.0",
+        "typed-function": "^2.1.0"
+      },
+      "bin": {
+        "mathjs": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/md5.js": {
@@ -9277,6 +9339,11 @@
         "object-assign": "^4.1.1"
       }
     },
+    "node_modules/seedrandom": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
+      "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg=="
+    },
     "node_modules/semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -9557,6 +9624,11 @@
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=",
       "dev": true
     },
+    "node_modules/tiny-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
+    },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
@@ -9664,6 +9736,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typed-function": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/typed-function/-/typed-function-2.1.0.tgz",
+      "integrity": "sha512-bctQIOqx2iVbWGDGPWwIm18QScpu2XRmkC19D8rQGFsjKSgteq/o1hTZvIG/wuDq8fanpBDrLkLq+aEN/6y5XQ==",
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/uncontrollable": {
@@ -10209,9 +10289,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.17.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.2.tgz",
-      "integrity": "sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==",
+      "version": "7.17.9",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.9.tgz",
+      "integrity": "sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==",
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -14387,6 +14467,11 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true
     },
+    "complex.js": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/complex.js/-/complex.js-2.1.0.tgz",
+      "integrity": "sha512-RdcrDz7YynXp/YXGwXIZ4MtmxXXniT5WmLFRX93cuXUX+0geWAqB8l1BoLXF+3BkzviVzHlpw27P9ow7MvlcmA=="
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -14715,6 +14800,11 @@
         "ms": "2.1.2"
       }
     },
+    "decimal.js": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.1.tgz",
+      "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ=="
+    },
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
@@ -14909,6 +14999,11 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
       "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
+    },
+    "escape-latex": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/escape-latex/-/escape-latex-1.2.0.tgz",
+      "integrity": "sha512-nV5aVWW1K0wEiUIEdZ4erkGGH8mDxGyxSeqPzRNtWP7ataw+/olFObw7hujFWlVjNsaDFw5VZ5NzVSIqRgfTiw=="
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -15277,6 +15372,11 @@
         "mime-types": "^2.1.12"
       }
     },
+    "fraction.js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.2.0.tgz",
+      "integrity": "sha512-MhLuK+2gUcnZe8ZHlaaINnQLl0xRIGRfcGk2yl8xoQAfHrSsL3rYu6FCmBdkdbhc9EPlwyGHewaRsvwRMJtAlA=="
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -15640,6 +15740,11 @@
       "optional": true,
       "peer": true
     },
+    "javascript-natural-sort": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
+      "integrity": "sha1-+eIwPUUH9tdDVac2ZNFED7Wg71k="
+    },
     "jest-diff": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.5.1.tgz",
@@ -15972,6 +16077,22 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
       "integrity": "sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY="
+    },
+    "mathjs": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-10.4.3.tgz",
+      "integrity": "sha512-C50lWorCOplBec9Ik5fzhHuOx4G4+mtdz3r1G2I1/r8yj+CpYFXLXNqTdg59oKmIF1tKcIzpxlC4s2dGL7f3pg==",
+      "requires": {
+        "@babel/runtime": "^7.17.8",
+        "complex.js": "^2.1.0",
+        "decimal.js": "^10.3.1",
+        "escape-latex": "^1.2.0",
+        "fraction.js": "^4.2.0",
+        "javascript-natural-sort": "^0.7.1",
+        "seedrandom": "^3.0.5",
+        "tiny-emitter": "^2.1.0",
+        "typed-function": "^2.1.0"
+      }
     },
     "md5.js": {
       "version": "1.3.5",
@@ -16902,6 +17023,11 @@
         "object-assign": "^4.1.1"
       }
     },
+    "seedrandom": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
+      "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg=="
+    },
     "semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -17115,6 +17241,11 @@
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=",
       "dev": true
     },
+    "tiny-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
+    },
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
@@ -17203,6 +17334,11 @@
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "dev": true
+    },
+    "typed-function": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/typed-function/-/typed-function-2.1.0.tgz",
+      "integrity": "sha512-bctQIOqx2iVbWGDGPWwIm18QScpu2XRmkC19D8rQGFsjKSgteq/o1hTZvIG/wuDq8fanpBDrLkLq+aEN/6y5XQ=="
     },
     "uncontrollable": {
       "version": "7.2.1",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "cosmjs-types": "^0.4.1",
     "dotenv": "^16.0.0",
     "fuzzy-search": "^3.2.1",
+    "mathjs": "^10.4.3",
     "moment": "^2.29.1",
     "parse-duration": "^1.0.2",
     "path": "^0.12.7",

--- a/scripts/base.mjs
+++ b/scripts/base.mjs
@@ -237,7 +237,7 @@ export class Autostake {
 
     const perValidatorReward = floor(divide(totalRewards, validators.length))
 
-    if (perValidatorReward < client.operator.minimumReward) {
+    if (perValidatorReward < bignumber(client.operator.minimumReward)) {
       timeStamp(address, perValidatorReward, client.network.denom, 'reward is too low, skipping')
       return
     }

--- a/scripts/base.mjs
+++ b/scripts/base.mjs
@@ -6,6 +6,7 @@ import {timeStamp, mapSync, executeSync, overrideNetworks} from '../src/utils/He
 import {
   coin
 } from '@cosmjs/stargate'
+import { divide, bignumber, floor } from 'mathjs'
 
 import { MsgWithdrawDelegatorReward } from "cosmjs-types/cosmos/distribution/v1beta1/tx.js";
 import { MsgDelegate } from "cosmjs-types/cosmos/staking/v1beta1/tx.js";
@@ -234,7 +235,7 @@ export class Autostake {
   async getAutostakeMessage(client, address, validators) {
     const totalRewards = await this.totalRewards(client, address, validators)
 
-    const perValidatorReward = parseInt(totalRewards / validators.length)
+    const perValidatorReward = floor(divide(totalRewards, validators.length))
 
     if (perValidatorReward < client.operator.minimumReward) {
       timeStamp(address, perValidatorReward, client.network.denom, 'reward is too low, skipping')
@@ -303,7 +304,7 @@ export class Autostake {
       value: MsgDelegate.encode(MsgDelegate.fromPartial({
         delegatorAddress: address,
         validatorAddress: validatorAddress,
-        amount: coin(amount, denom)
+        amount: coin(amount.toString(), denom)
       })).finish()
     }]
   }
@@ -316,7 +317,7 @@ export class Autostake {
           const total = Object.values(rewards).reduce((sum, item) => {
             const reward = item.reward.find(el => el.denom === client.network.denom)
             if (reward && validators.includes(item.validator_address)) {
-              return sum + parseInt(reward.amount)
+              return sum + bignumber(reward.amount)
             }
             return sum
           }, 0)

--- a/src/components/Delegate.js
+++ b/src/components/Delegate.js
@@ -101,7 +101,7 @@ function Delegate(props) {
   const bondedTokens = () => {
     if (!selectedValidator) return
 
-    const amount = parseInt(selectedValidator.tokens)
+    const amount = selectedValidator.tokens
     return <Coins coins={{ amount: amount, denom: network.denom }} />
   }
 

--- a/src/components/Delegations.js
+++ b/src/components/Delegations.js
@@ -1,5 +1,6 @@
 import React from "react";
 import _ from "lodash";
+import { bignumber } from 'mathjs'
 import { Bech32 } from '@cosmjs/encoding'
 import AlertMessage from "./AlertMessage";
 import Coins from "./Coins";
@@ -306,7 +307,7 @@ class Delegations extends React.Component {
           const reward = validatorReward.reward.find((el) => el.denom === denom)
           return {
             validatorAddress: validator,
-            reward: reward ? parseInt(reward.amount) : undefined,
+            reward: reward ? bignumber(reward.amount) : undefined,
           }
         })
         .filter(validatorReward => {

--- a/src/networks.json
+++ b/src/networks.json
@@ -91,7 +91,8 @@
   },
   {
     "name": "sifchain",
-    "authzSupport": false
+    "authzSupport": false,
+    "gasPrice": "1500000000000rowan"
   },
   {
     "name": "lumnetwork",
@@ -150,6 +151,7 @@
   },
   {
     "name": "fetchhub",
+    "gasPrice": "5000afet",
     "authzSupport": true
   },
   {

--- a/src/utils/Network.mjs
+++ b/src/utils/Network.mjs
@@ -1,4 +1,5 @@
 import _ from 'lodash'
+import { multiply, pow } from 'mathjs'
 import QueryClient from './QueryClient.mjs'
 import SigningClient from './SigningClient.mjs'
 import ApyClient from '../ApyClient.mjs'
@@ -31,8 +32,9 @@ const Network = async (data, withoutQueryClient) => {
 
   const signingClient = (wallet, key) => {
     if(!queryClient) return 
-
-    const gasPrice = data.gasPrice || '0.0025' + chain.denom
+    
+    const defaultGasPrice = multiply(0.000000025, pow(10, chain.decimals)).toString() + chain.denom
+    const gasPrice = data.gasPrice || defaultGasPrice
     const client = SIGNERS[data.name] || SigningClient
     return client(queryClient.rpcUrl, gasPrice, wallet, key)
   }

--- a/src/utils/Network.mjs
+++ b/src/utils/Network.mjs
@@ -23,7 +23,14 @@ const Network = async (data, withoutQueryClient) => {
   const rpcUrl = data.rpcUrl || directory.rpcUrl(data.name)
   const restUrl = data.restUrl || directory.restUrl(data.name)
 
-  const usingDirectory = !![restUrl, rpcUrl].find(el => el.match("cosmos.directory"))
+  const usingDirectory = !![restUrl, rpcUrl].find(el => {
+    const match = el => el.match("cosmos.directory")
+    if(Array.isArray(el)){
+      return el.find(match)
+    }else{
+      return match(el)
+    }
+  })
 
   let queryClient
   if(!withoutQueryClient){

--- a/src/utils/QueryClient.mjs
+++ b/src/utils/QueryClient.mjs
@@ -2,14 +2,19 @@ import axios from "axios";
 import _ from "lodash";
 
 const QueryClient = async (chainId, rpcUrls, restUrls) => {
-  const rpcUrl = await findAvailableUrl(
-    Array.isArray(rpcUrls) ? rpcUrls : [rpcUrls],
-    "rpc"
-  );
-  const restUrl = await findAvailableUrl(
-    Array.isArray(restUrls) ? restUrls : [restUrls],
-    "rest"
-  );
+  let rpcUrl, restUrl
+  try {
+    rpcUrl = await findAvailableUrl(
+      Array.isArray(rpcUrls) ? rpcUrls : [rpcUrls],
+      "rpc"
+    );
+  } catch {}
+  try {
+    restUrl = await findAvailableUrl(
+      Array.isArray(restUrls) ? restUrls : [restUrls],
+      "rest"
+    );
+  } catch {}
 
   const getAllValidators = (pageSize, opts, pageCallback) => {
     return getAllPages((nextKey) => {


### PR DESCRIPTION
Avoids JS integer types for potentially large numbers. Changes the default fee (if not set in networks.json) to be a factor of chain decimals. For a 6 decimal chain this would be 0.025 (which is a change from 0.0025 previously).

Also updates Fetchhub and Sifchain to use roughly the same gas price config as Keplr. Huge variance here given both chains are 18 decimals.

Resolves #133 
Resolves #410 