### PR TITLE
Add ledger instructions

### DIFF
--- a/src/components/About.js
+++ b/src/components/About.js
@@ -1,11 +1,30 @@
+import React, { useEffect } from 'react';
 import {
   Modal
 } from 'react-bootstrap'
 
+import { useSearchParams } from 'react-router-dom'
+
 function About(props) {
+  let [searchParams, setSearchParams] = useSearchParams();
+  const aboutParam = searchParams.get('about')
+
+  const show = props.show || aboutParam == 'restake'
+
+  useEffect(() => {
+    if (show && !aboutParam) {
+      setSearchParams({ about: 'restake' })
+    }
+  }, [show, aboutParam]);
+
+  function onHide(){
+    setSearchParams({})
+    props.onHide()
+  }
+
   return (
     <>
-      <Modal show={props.show} onHide={() => props.onHide()}>
+      <Modal show={show} onHide={() => onHide()}>
         <Modal.Header closeButton>
           <Modal.Title>About REStake</Modal.Title>
         </Modal.Header>

--- a/src/components/AboutLedger.js
+++ b/src/components/AboutLedger.js
@@ -1,0 +1,125 @@
+import React, { useEffect } from 'react';
+import {
+  Modal
+} from 'react-bootstrap'
+
+import { useSearchParams } from 'react-router-dom'
+
+function AboutLedger(props) {
+  let [searchParams, setSearchParams] = useSearchParams();
+  const aboutParam = searchParams.get('about')
+
+  const { network, validator } = props
+  const { daemon_name, chain_id, node_home, codebase } = network.chain.chainData
+  const { git_repo, binaries } = codebase || {}
+
+  const address = validator?.restake.address || <kbd>GrantAddress</kbd>
+
+  const show = props.show || (aboutParam == 'ledger' && network.authzSupport)
+
+  useEffect(() => {
+    if (show && !aboutParam) {
+      setSearchParams({ about: 'ledger' })
+    }
+  }, [show, aboutParam]);
+
+  function onHide(){
+    setSearchParams({})
+    props.onHide()
+  }
+
+  const content = (
+    <>
+      <h5>How to use a Ledger with {validator ? validator.name : 'REStake'}</h5>
+      <p>Right now there is a limitation in Cosmos SDK which prevents using a Ledger device with the REStake UI. It is possible though to send a slightly modified version of the grants using the {network.prettyName} CLI client.</p>
+      <p>The commands needed are detailed below thanks to the awesome <a href="https://twitter.com/gjermundbjaanes" target="_blank">@gjermundbjaanes</a> who put together <a href="https://gjermund.tech/blog/making-ledger-work-on-restake/" target="_blank">a more detailed guide and CLI tool</a> to make the process easier.</p>
+      <p>{!validator ? <span>You can find <strong>validator specific instructions</strong> in a tab on the validator's page, with their REStake address pre-filled.</span> : `${validator.name}'s REStake address has been pre-filled below.`} Instructions are specific to the Network you have selected.</p>
+      <p><strong>You should only attempt this if you have a basic understanding of using a command line tool.</strong></p>
+      <h5>Download CLI client for {network.prettyName}</h5>
+      <p>Skip this step if you've already installed <code>{daemon_name || network.prettyName}</code>.</p>
+      {
+        binaries && (
+          <>
+            <h6>Install from pre-built binaries</h6>
+            <p>Download one of the pre-built binaries and use that instead of building from source.</p>
+            <p>The binary <strong>may not have been built with ledger support</strong> so you might still need the source method.</p>
+            <p>
+              {Object.entries(binaries).map(([key, item]) => {
+                return (
+                  <span key={key}><strong>{key}:</strong> <a href={item} target="_blank">{item}</a><br /></span>
+                )
+              })}</p>
+            <h6>Alternative install from source</h6>
+          </>
+        )
+      }
+      {
+        git_repo
+          ? (
+            <>
+              <p>Clone and install the <code>{daemon_name || network.prettyName}</code> CLI client from <a href={git_repo} target="_blank">{git_repo}</a>. The standard Tendermint installation process is detailed below, but you might need to check the documentation for project specific install.</p>
+              <pre className="pre-scrollable text-wrap"><code>
+                <p>git clone {git_repo} restake_{network.name}</p>
+                <p>cd restake_{network.name}</p>
+                <p>make install</p>
+              </code></pre>
+            </>
+          ) : (
+            <p>Download and install the <code>{daemon_name || network.prettyName}</code> CLI client from the project's documentation.</p>
+          )
+      }
+      <h5>Add Ledger as a key</h5>
+      <p>Skip this step if you already have your ledger setup with <code>{daemon_name || network.prettyName}</code>.</p>
+      <p>Add your Ledger as a new key. The below example will use the key name <kbd>ledger</kbd> and the default install directory{node_home ? <>(<code>{node_home}</code>)</> : ''}.</p>
+      <p>Make sure your Ledger is plugged in, unlocked and the Cosmos app is open.</p>
+      <pre className="text-wrap"><code>
+        <p>{daemon_name ? daemon_name : <kbd>DaemonName</kbd>} keys add <kbd>ledger</kbd> --ledger --keyring-backend file</p>
+      </code></pre>
+      <h5>Grant permission to withdraw delegator rewards</h5>
+      <p>Next you need to grant the first of two permissions required for REStake to function. This is the <code>WithdrawDelegatorReward</code> grant and is identical to the one the REStake UI would set.</p>
+      {!validator && <p>Make sure you enter your validator's REStake address in place of {address}. You can find instructions in a tab on the validator's page with their address pre-filled.</p>}
+      {validator && <p>{validator.name}'s REStake address has been pre-filled below (<code>{address}</code>).</p>}
+      <pre className="text-wrap"><code>
+        <p>{daemon_name ? daemon_name : <kbd>DaemonName</kbd>} tx authz grant {address} generic --msg-type /cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward --from <kbd>ledger</kbd> --ledger --chain-id {chain_id} --node https://rpc.cosmos.directory:443/{network.name} --keyring-backend file --gas auto --gas-prices {network.gasPrice} --gas-adjustment 1.5</p>
+      </code></pre>
+      <h5>Grant permission to delegate rewards</h5>
+      <p>Finally you need to grant the final permission to allow the validator to send <code>Delegate</code> messages. This is different to the REStake UI which also limits the validator address the address can delegate to. The REStake script will handle this difference and it doesn't present much of a security problem.</p>
+      {!validator && <p>Make sure you enter your validator's REStake address in place of {address}. You can find instructions in a tab on the validator's page with their address pre-filled.</p>}
+      {validator && <p>{validator.name}'s REStake address has been pre-filled below (<code>{address}</code>).</p>}
+      <pre className="text-wrap"><code>
+        <p>{daemon_name ? daemon_name : <kbd>DaemonName</kbd>} tx authz grant {address} generic --msg-type /cosmos.staking.v1beta1.MsgDelegate --from <kbd>ledger</kbd> --ledger --chain-id {chain_id} --node https://rpc.cosmos.directory:443/{network.name} --keyring-backend file --gas auto --gas-prices {network.gasPrice} --gas-adjustment 1.5</p>
+      </code></pre>
+      <h5>Fin.</h5>
+      <p>That's it! <strong>So long as you have an active delegation with them,</strong> your validator should now pick up your ledger's address as a valid REStake user if they're running the latest version. If you don't see the restaking happening, reach out to them to update.</p>
+      <p>The UI will show the current state of your grant with the validator, you just won't be able to revoke.</p>
+      <p>We will make sure the UI supports these grant types once Ledger integration is possible.</p>
+      <p>For more detailed instructions check out <a href="https://twitter.com/gjermundbjaanes" target="_blank">@gjermundbjaanes</a>'s awesome <a href="https://gjermund.tech/blog/making-ledger-work-on-restake/" target="_blank">guide and helper tool</a>.</p>
+      <hr />
+      <h5>Revoke permissions</h5>
+      <p>Revoking the grants is just another command. You need to revoke each permission individually.</p>
+      {!validator && <p>Make sure you enter your validator's REStake address in place of {address}. You can find instructions in a tab on the validator's page with their address pre-filled.</p>}
+      {validator && <p>{validator.name}'s REStake address has been pre-filled below (<code>{address}</code>).</p>}
+      <pre className="text-wrap"><code>
+        <p>{daemon_name ? daemon_name : <kbd>DaemonName</kbd>} tx authz revoke {address} /cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward --from <kbd>ledger</kbd> --ledger --chain-id {chain_id} --node https://rpc.cosmos.directory:443/{network.name} --keyring-backend file --gas auto --gas-prices {network.gasPrice} --gas-adjustment 1.5</p>
+        <p>{daemon_name ? daemon_name : <kbd>DaemonName</kbd>} tx authz revoke {address} /cosmos.staking.v1beta1.MsgDelegate --from <kbd>ledger</kbd> --ledger --chain-id {chain_id} --node https://rpc.cosmos.directory:443/{network.name} --keyring-backend file --gas auto --gas-prices {network.gasPrice} --gas-adjustment 1.5</p>
+      </code></pre>
+    </>
+  )
+
+  if(props.modal === false) return <div className="small">{content}</div>;
+
+  return (
+    <>
+      <Modal size="lg" show={show} onHide={() => onHide()}>
+        <Modal.Header closeButton>
+          <Modal.Title>Ledger</Modal.Title>
+        </Modal.Header>
+        <Modal.Body className="small">
+          {content}
+        </Modal.Body>
+      </Modal>
+    </>
+  );
+}
+
+export default AboutLedger

--- a/src/components/App.css
+++ b/src/components/App.css
@@ -26,3 +26,12 @@ header a.moniker{
   line-height: 70px;
   font-size: 1.3rem;
 }
+
+code {
+  padding: 0.5rem;
+  line-height:1.5rem;
+}
+
+code p{
+  margin-bottom: 0.5rem;
+}

--- a/src/components/Delegate.js
+++ b/src/components/Delegate.js
@@ -6,6 +6,7 @@ import ValidatorImage from './ValidatorImage'
 import ValidatorLink from './ValidatorLink'
 import Coins from './Coins'
 import TooltipIcon from './TooltipIcon'
+import AboutLedger from './AboutLedger';
 
 import {
   Dropdown,
@@ -39,6 +40,14 @@ function Delegate(props) {
     setShow(true)
     if (!validator || redelegate) {
       setSelectedValidator(null)
+    }
+  }
+
+  const handleClose = () => {
+    if(selectedValidator && (!validator || redelegate) && selectedValidator !== validator){
+      setSelectedValidator(null)
+    }else{
+      setShow(false)
     }
   }
 
@@ -164,7 +173,7 @@ function Delegate(props) {
   return (
     <>
       {button()}
-      <Modal size={selectedValidator ? '' : 'lg'} show={show} onHide={() => setShow(false)}>
+      <Modal size={selectedValidator ? 'lg' : 'lg'} show={show} onHide={handleClose}>
         <Modal.Header closeButton>
           <Modal.Title>
             {selectedValidator
@@ -200,9 +209,15 @@ function Delegate(props) {
                       </tr>
                     )}
                     <tr>
-                      <td scope="row">Address</td>
-                      <td className="text-break small">{selectedValidator.operator_address}</td>
+                      <td scope="row">Validator Address</td>
+                      <td className="text-break">{selectedValidator.operator_address}</td>
                     </tr>
+                    {operator() && (
+                    <tr>
+                      <td scope="row">REStake Address</td>
+                      <td className="text-break">{operator().botAddress}</td>
+                    </tr>
+                    )}
                     {!active() && (
                       <tr>
                         <td scope="row">Status</td>
@@ -212,7 +227,7 @@ function Delegate(props) {
                     {!!website() && (
                       <tr>
                         <td scope="row">Website</td>
-                        <td><ValidatorLink validator={selectedValidator}>{website()}</ValidatorLink></td>
+                        <td><ValidatorLink className="text-decoration-underline" validator={selectedValidator}>{website()}</ValidatorLink></td>
                       </tr>
                     )}
                     <tr>
@@ -270,7 +285,7 @@ function Delegate(props) {
                 <p>{selectedValidator.description.details}</p>
                 <p className="text-end">
                   <Button variant="primary" onClick={() => { setActiveTab('delegate') }}>
-                    {actionText()}
+                    Delegate
                   </Button>
                 </p>
               </Tab>
@@ -292,6 +307,11 @@ function Delegate(props) {
                   stargateClient={props.stargateClient}
                   onDelegate={onDelegate} />
               </Tab>
+              {network.authzSupport && operator() && (
+                <Tab eventKey="ledger" title="Ledger Instructions">
+                  <AboutLedger network={network} validator={selectedValidator} modal={false} />
+                </Tab>
+              )}
             </Tabs>
           )}
         </Modal.Body>

--- a/src/components/Delegations.js
+++ b/src/components/Delegations.js
@@ -11,6 +11,7 @@ import CountdownRestake from "./CountdownRestake";
 import Delegate from "./Delegate";
 import ValidatorImage from "./ValidatorImage";
 import TooltipIcon from "./TooltipIcon";
+import AboutLedger from "./AboutLedger";
 
 import { Table, Button, Dropdown, Spinner } from "react-bootstrap";
 
@@ -650,13 +651,21 @@ class Delegations extends React.Component {
         {this.authzSupport() &&
           this.props.operators.length > 0 &&
           this.state.isNanoLedger && (
-            <AlertMessage
-              variant="warning"
-              message="Ledger devices are unable to send authz transactions right now. We will support them as soon as possible, and you can manually restake for now."
-              dismissible={false}
-            />
+            <>
+              <AlertMessage
+                variant="warning"
+                message=""
+                dismissible={false}
+              >
+                <p>Ledger devices are not supported in the REStake UI currently. Support will be added as soon as it is possible.</p>
+                <p className="mb-0"><span onClick={() => this.setState({ showAboutLedger: true })} role="button" className="text-dark text-decoration-underline">A manual workaround is possible using the CLI</span></p>
+            </AlertMessage>
+          </>
           )}
         <AlertMessage message={this.state.error} />
+        {this.props.network && (
+          <AboutLedger show={this.state.showAboutLedger} onHide={() => this.setState({ showAboutLedger: false })} network={this.props.network} />
+        )}
       </>
     );
 

--- a/src/components/Delegations.js
+++ b/src/components/Delegations.js
@@ -100,7 +100,7 @@ class Delegations extends React.Component {
   }
 
   async calculateApy() {
-    if(this.props.network.apyEnabled === false) return
+    if(this.props.network.apyEnabled === false || !this.props.network.getApy) return
 
     this.props.network.getApy(
       this.props.validators,

--- a/src/components/Delegations.js
+++ b/src/components/Delegations.js
@@ -123,21 +123,22 @@ class Delegations extends React.Component {
 
         return this.props.queryClient.getGrants(botAddress, this.props.address).then(
           (result) => {
+            const { claimGrant, stakeGrant } = result
             let grantValidators;
-            if (result.stakeGrant) {
+            if (stakeGrant) {
               grantValidators =
-                result.stakeGrant.authorization.allow_list.address;
+                stakeGrant.authorization.allow_list?.address;
             }
             const operatorGrant = {
-              claimGrant: result.claimGrant,
-              stakeGrant: result.stakeGrant,
+              claimGrant: claimGrant,
+              stakeGrant: stakeGrant,
               validators: grantValidators || [],
               grantsValid: !!(
-                result.claimGrant &&
-                result.stakeGrant &&
-                grantValidators.includes(address)
+                claimGrant &&
+                stakeGrant &&
+                (!grantValidators || grantValidators.includes(address))
               ),
-              grantsExist: !!(result.claimGrant || result.stakeGrant),
+              grantsExist: !!(claimGrant || stakeGrant),
             };
             this.setState((state, props) => ({
               operatorGrants: _.set(
@@ -376,13 +377,13 @@ class Delegations extends React.Component {
           </td>
           <td className="text-center">
             {operator ? (
-              this.restakePossible() && delegation ? (
+              this.authzSupport() && delegation ? (
                 this.grantsValid(operator) ? (
                   <CountdownRestake
                     network={this.props.network}
                     operator={operator}
                   />
-                ) : (
+                ) : this.restakePossible() ? (
                   <GrantRestake
                     size="sm"
                     variant="success"
@@ -392,6 +393,12 @@ class Delegations extends React.Component {
                     stargateClient={this.props.stargateClient}
                     onGrant={this.onGrant}
                     setError={this.setError}
+                  />
+                ) : (
+                  <TooltipIcon
+                    icon={<CheckCircle className="text-success" />}
+                    identifier={validatorAddress}
+                    tooltip="This validator can REStake your rewards"
                   />
                 )
               ) : (

--- a/src/components/ValidatorName.js
+++ b/src/components/ValidatorName.js
@@ -6,7 +6,7 @@ import {
 function ValidatorName(props) {
   const { validator, hideWarning, fallback } = props
   if(!validator) return fallback || null
-  const { moniker } = validator.description
+  const moniker = validator.description?.moniker || validator.name || 'Unknown'
 
   let warning = false
   let warningClass

--- a/src/utils/Network.mjs
+++ b/src/utils/Network.mjs
@@ -32,6 +32,8 @@ const Network = async (data, withoutQueryClient) => {
     }
   })
 
+  const defaultGasPrice = multiply(0.000000025, pow(10, chain.decimals)).toString() + chain.denom
+
   let queryClient
   if(!withoutQueryClient){
     queryClient = await QueryClient(chain.chainId, rpcUrl, restUrl)
@@ -40,7 +42,6 @@ const Network = async (data, withoutQueryClient) => {
   const signingClient = (wallet, key) => {
     if(!queryClient) return 
     
-    const defaultGasPrice = multiply(0.000000025, pow(10, chain.decimals)).toString() + chain.denom
     const gasPrice = data.gasPrice || defaultGasPrice
     const client = SIGNERS[data.name] || SigningClient
     return client(queryClient.rpcUrl, gasPrice, wallet, key)
@@ -88,7 +89,7 @@ const Network = async (data, withoutQueryClient) => {
     chainId: chain.chainId,
     prefix: chain.prefix,
     slip44: chain.slip44,
-    gasPrice: data.gasPrice,
+    gasPrice: data.gasPrice || defaultGasPrice,
     denom: chain.denom,
     symbol: chain.symbol,
     decimals: chain.decimals,


### PR DESCRIPTION
Thanks to @bjaanes for creating https://gjermund.tech/blog/making-ledger-work-on-restake/.

This PR adds basic instructions on how to use REStake with a ledger device. The instructions are dynamic based on network, and there is a new tab in the operators modal for operator specific instructions. It also adapts the UI to handle these grants correctly, and allows URL linking to both About modals. 

These instructions are meant to be for more advanced users, and links to @bjaanes blog post for more detail. It's a very quick process once you're familiarised. 

Resolves #423 