### PR TITLE
security: bump moment due to GHSA-8hfj-j24r-96c4

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "dotenv": "^16.0.0",
     "fuzzy-search": "^3.2.1",
     "mathjs": "^10.4.3",
-    "moment": "^2.29.1",
+    "moment": "^2.29.2",
     "parse-duration": "^1.0.2",
     "path": "^0.12.7",
     "react": "^17.0.2",


### PR DESCRIPTION
This PR bumps moment to a higher version, doesn't look like there are any breaking exchanges except bugfix

### safu?
Yes, restake doesn't pass any user input to moment. Nevertheless, it pays to keep `npm audit` happy
```javascript
$ grep -air -5 moment
utils/Operator.mjs:import moment from 'moment'
utils/Operator.mjs-import parse from 'parse-duration'
utils/Operator.mjs-
utils/Operator.mjs-const Operator = (data) => {
utils/Operator.mjs-  const { address } = data
utils/Operator.mjs-  const botAddress = data.restake.address
--
utils/Operator.mjs-    }
utils/Operator.mjs-  }
utils/Operator.mjs-
utils/Operator.mjs-  function nextRunFromInterval(runTime){
utils/Operator.mjs-    const interval = parse(runTime.replace('every ', ''))
utils/Operator.mjs:    const diff = moment().startOf('day').diff()
utils/Operator.mjs-    const ms = interval + diff % interval
utils/Operator.mjs:    return moment().add(ms, 'ms')
utils/Operator.mjs-  }
utils/Operator.mjs-
utils/Operator.mjs-  function nextRunFromRuntime(runTime) {
utils/Operator.mjs:    const date = moment.utc(runTime, 'HH:mm:ss')
utils/Operator.mjs-    return date.isAfter() ? date : date.add(1, 'day')
utils/Operator.mjs-  }

````