### PR TITLE
Speed up network load

### DIFF
--- a/scripts/base.mjs
+++ b/scripts/base.mjs
@@ -89,8 +89,9 @@ export class Autostake {
   }
 
   async getClient(data) {
-    let network = await Network(data, true)
+    let network = new Network(data)
     let slip44
+    await network.load()
 
     timeStamp('⚛')
     timeStamp('Starting', network.prettyName)
@@ -129,7 +130,7 @@ export class Autostake {
 
     if (!network.authzSupport) return timeStamp('No Authz support')
 
-    network = await Network(data)
+    await network.connect()
     if (!network.rpcUrl) return timeStamp('Could not connect to RPC API')
     if (!network.restUrl) return timeStamp('Could not connect to REST API')
 

--- a/scripts/checkAuthz.mjs
+++ b/scripts/checkAuthz.mjs
@@ -10,7 +10,9 @@ async function checkAuthz(networkName) {
     return async () => {
       if(networkName && data.name !== networkName) return
       try {
-        const network = await Network(data)
+        const network = new Network(data)
+        await network.load()
+        await network.connect()
         const support = await testAuthz(network)
         if (data.authzSupport !== support){
           console.log(network.name, 'support is different', support ? 'ENABLED' : 'DISABLED')

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -42,7 +42,7 @@ class App extends React.Component {
     if(this.state.keplr != prevState.keplr){
       this.connect()
     }else if(this.props.network && this.props.network !== prevProps.network){
-      this.setState({ balance: undefined })
+      this.setState({ balance: undefined, address: undefined })
       this.connect()
     }
   }
@@ -103,7 +103,8 @@ class App extends React.Component {
       } catch (e) {
         console.log(e)
         return this.setState({
-          error: 'Failed to connect to signing client. API may be down'
+          error: 'Failed to connect to signing client. API may be down.',
+          loading: false
         })
       }
     }

--- a/src/components/Delegations.js
+++ b/src/components/Delegations.js
@@ -678,7 +678,6 @@ class Delegations extends React.Component {
             <>
               <AlertMessage
                 variant="warning"
-                message=""
                 dismissible={false}
               >
                 <p>Ledger devices are not supported in the REStake UI currently. Support will be added as soon as it is possible.</p>

--- a/src/components/NetworkFinder.js
+++ b/src/components/NetworkFinder.js
@@ -74,16 +74,18 @@ function NetworkFinder() {
       if(params.network != networkName){
         navigate("/" + networkName);
       }
-      Network(data).then(network => {
-        if(network.connected){
-          setState({ network: network })
-        }else{
-          throw false
-        }
-      }).catch(error => {
-        Network(data, true).then(network => {
-          setState({ network: network, loading: false })
+      const network = new Network(data)
+      network.load().then(() => {
+        return network.connect().then(() => {
+          if (network.connected) {
+            setState({ network: network })
+          } else {
+            throw false
+          }
         })
+      }).catch(error => {
+        console.log(error)
+        setState({ network: network, loading: false })
       })
     }
   }, [state.networks, state.network, params.network, navigate])

--- a/src/components/NetworkSelect.js
+++ b/src/components/NetworkSelect.js
@@ -89,12 +89,14 @@ function NetworkSelect(props) {
     const networks = Object.values(props.networks).sort((a, b) => a.name > b.name ? 1 : -1)
     setOptions({
       networks: networks.map(el => {
+        const network = new Network(el)
         return {
           value: el.name, 
           label: el.pretty_name, 
           image: el.image,
           operatorCount: el.operators?.length || operatorCounts[el.name], 
-          authz: el.authzSupport
+          authz: el.authzSupport,
+          online: !network.usingDirectory || directoryConnected(el)
         }
       }),
       network: selectedNetwork && {
@@ -102,7 +104,8 @@ function NetworkSelect(props) {
         label: selectedNetwork.prettyName,
         image: selectedNetwork.image,
         operatorCount: selectedNetwork.operators?.length,
-        authz: selectedNetwork.authzSupport
+        authz: selectedNetwork.authzSupport,
+        online: true // modal will show status
       }
     })
   }, [props.networks, selectedNetwork, operatorCounts])
@@ -143,12 +146,12 @@ function NetworkSelect(props) {
                   options={options.networks}
                   onChange={selectNetwork}
                   formatOptionLabel={network => (
-                    <div className="row">
+                    <div className={ 'row' + (!network.online ? ' text-muted' : '') }>
                       <div className="col-1">
                         <img src={network.image} width={30} height={30} alt={network.label} />
                       </div>
                       <div className="col pt-1">
-                        <span className="ms-1">{network.label}</span>
+                        <span className="ms-1">{network.label} {!network.online && <small>(Offline)</small>}</span>
                       </div>
                       <div className="col text-end pt-1">
                         {network.operatorCount > 0 &&

--- a/src/components/Wallet.js
+++ b/src/components/Wallet.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import Delegations from './Delegations'
+import AlertMessage from './AlertMessage';
 
 import {
   Spinner
@@ -56,14 +57,15 @@ class Wallet extends React.Component {
           });
         },
         (error) => {
-          this.setState({ isLoaded: true })
           if([404, 500].includes(error.response && error.response.status)){
             this.setState({
-              delegations: {}
+              delegations: {},
+              isLoaded: true
             });
           }else if(!hideError){
             this.setState({
-              error: 'Failed to load delegations. Please refresh.'
+              error: 'Failed to load delegations. API may be down.',
+              isLoaded: true
             });
           }
         }
@@ -82,7 +84,7 @@ class Wallet extends React.Component {
     }
     if (this.state.error) {
       return (
-        <p>Loading failed</p>
+        <AlertMessage message={this.state.error} />
       )
     }
     return (

--- a/src/utils/QueryClient.mjs
+++ b/src/utils/QueryClient.mjs
@@ -2,14 +2,8 @@ import axios from "axios";
 import _ from "lodash";
 
 const QueryClient = async (chainId, rpcUrls, restUrls) => {
-  const rpcUrl = await findAvailableUrl(
-    Array.isArray(rpcUrls) ? rpcUrls : [rpcUrls],
-    "rpc"
-  );
-  const restUrl = await findAvailableUrl(
-    Array.isArray(restUrls) ? restUrls : [restUrls],
-    "rest"
-  );
+  let rpcUrl = await findAvailableUrl(rpcUrls, "rpc")
+  let restUrl = await findAvailableUrl(restUrls, "rest")
 
   const getAllValidators = (pageSize, opts, pageCallback) => {
     return getAllPages((nextKey) => {
@@ -183,6 +177,13 @@ const QueryClient = async (chainId, rpcUrls, restUrls) => {
   };
 
   async function findAvailableUrl(urls, type) {
+    if (!Array.isArray(urls)) {
+      if(urls.match('cosmos.directory')){
+        return urls // cosmos.directory health checks already
+      }else{
+        urls = [urls]
+      }
+    }
     const path = type === "rest" ? "/blocks/latest" : "/block";
     return Promise.any(urls.map(async (url) => {
       try {


### PR DESCRIPTION
Refactor how a network is initialised and loaded. Skip the chain ID check for cosmos.directory as health checks are done there instead. Drastically improves initial load/changing network. 

Also shows unavailable networks as muted in the network select.