### PR TITLE
Autostake use remaining grant

### DIFF
--- a/src/components/ValidatorGrants.js
+++ b/src/components/ValidatorGrants.js
@@ -197,7 +197,8 @@ function ValidatorGrants(props) {
                 : grantsExist
                   ? state.maxTokens && smaller(state.maxTokens, props.rewards)
                     ? <span className="text-danger">Not enough grant remaining</span>
-                    : <span className="text-danger">Invalid</span> : <em>Inactive</em>}
+                    : <span className="text-danger">Invalid / total delegation reached</span> 
+                  : <em>Inactive</em>}
             </td>
           </tr>
         </tbody>


### PR DESCRIPTION
If the user has a maximum delegation set on their grant, the autostake script will skip them if the remaining amount isn't enough.

This PR adjust that behaviour to use the remaining amount for the final delegation. The StakeAuthorization will then automatically revoke and need to be re-granted. 