### PR TITLE
Allow UI gas price override

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -74,20 +74,26 @@ class App extends React.Component {
         error: 'Could not connect to any available API servers'
       })
     }
-    const chainId = this.props.network.chainId
+    const { network } = this.props
+    const chainId = network.chainId
     try {
       if (window.keplr) {
+        if(network.gasPricePrefer){
+          window.keplr.defaultOptions = {
+            sign: { preferNoSetFee: true }
+          }
+        }
         await window.keplr.enable(chainId);
       }
     } catch (e) {
       console.log(e.message, e)
-      await this.suggestChain(this.props.network)
+      await this.suggestChain(network)
     }
     if (window.getOfflineSigner) {
       try {
         const offlineSigner = await window.getOfflineSignerAuto(chainId)
         const key = await window.keplr.getKey(chainId);
-        const stargateClient = await this.props.network.signingClient(offlineSigner, key)
+        const stargateClient = await network.signingClient(offlineSigner, key, network.gasPricePrefer)
 
         const address = await stargateClient.getAddress()
 
@@ -96,7 +102,7 @@ class App extends React.Component {
         this.setState({
           address: address,
           stargateClient: stargateClient,
-          queryClient: this.props.network.queryClient,
+          queryClient: network.queryClient,
           error: false
         })
         this.getBalance()

--- a/src/components/DelegateForm.js
+++ b/src/components/DelegateForm.js
@@ -127,7 +127,7 @@ class DelegateForm extends React.Component {
             <Form.Label>Amount</Form.Label>
             <div className="mb-3">
               <div className="input-group">
-                <Form.Control name="amount" type="number" step={0.000001} placeholder="10" required={true} value={this.state.amount} onChange={this.handleInputChange} />
+                <Form.Control name="amount" type="number" min={0} step={0.000001} placeholder="10" required={true} value={this.state.amount} onChange={this.handleInputChange} />
                 <span className="input-group-text">{this.denom()}</span>
               </div>
               {this.props.availableBalance &&

--- a/src/networks.json
+++ b/src/networks.json
@@ -134,6 +134,7 @@
   {
     "name": "impacthub",
     "gasPrice": "0.025uixo",
+    "gasPricePrefer": "0.1uixo",
     "authzSupport": false
   },
   {
@@ -167,6 +168,7 @@
   {
     "name": "secretnetwork",
     "gasPrice": "0.025uscrt",
+    "gasPricePrefer": "0.05uscrt",
     "authzSupport": true
   },
   {

--- a/src/utils/Network.mjs
+++ b/src/utils/Network.mjs
@@ -49,9 +49,10 @@ class Network {
     this.image = this.chain.image
     this.coinGeckoId = this.chain.coinGeckoId
     this.authzSupport = this.chain.authzSupport
-    const defaultGasPrice = format(bignumber(multiply(0.000000025, pow(10, this.chain.decimals))), { notation: 'fixed' }) + this.chain.denom
+    const defaultGasPrice = format(bignumber(multiply(0.000000025, pow(10, this.decimals))), { notation: 'fixed' }) + this.denom
     this.gasPrice = this.data.gasPrice || defaultGasPrice
     this.gasPriceStep = this.data.gasPriceStep
+    this.gasPricePrefer = this.data.gasPricePrefer
   }
 
   async connect() {
@@ -68,12 +69,12 @@ class Network {
     }
   }
 
-  signingClient(wallet, key) {
+  signingClient(wallet, key, gasPrice) {
     if (!this.queryClient)
       return
 
     const client = this.SIGNERS[this.data.name] || SigningClient
-    return client(this.queryClient.rpcUrl, this.gasPrice, wallet, key)
+    return client(this.queryClient.rpcUrl, gasPrice || this.gasPrice, wallet, key)
   }
 
   getOperator(operatorAddress) {


### PR DESCRIPTION
Allows a `gasPricePrefer` attribute in networks.json to force the Keplr gas price in the UI. This handles public nodes with higher than normal gas prices. 

With ImpactHub, all current nodes seem to have 0.1uixo fees, which doesn't seem to match docs. The UI will now force 0.1 in Keplr, still allowing the user to override to the default. Note we can't fix IXO with suggestChain because it's a native Keplr chain. Resolves #455 

With Secret, at least one node has double the normal gas prices. Error comes up often enough, and x2 isn't huge, so forcing that here too. Resolves #432 

Note none of this will affect autostaking, as we expect operators to use their own nodes without these issues. 