### PR TITLE
Enable APR/APY for Juno, Desmos and Comdex

### DIFF
--- a/src/networks.json
+++ b/src/networks.json
@@ -6,7 +6,6 @@
   },
   {
     "name": "juno",
-    "apyEnabled": false,
     "gasPrice": "0.0025ujuno"
   },
   {
@@ -61,7 +60,6 @@
   },
   {
     "name": "desmos",
-    "apyEnabled": false,
     "gasPrice": "0.001udsm"
   },
   {
@@ -87,7 +85,6 @@
   },
   {
     "name": "comdex",
-    "apyEnabled": false,
     "ownerAddress": "comdexvaloper17f70yjkvmvld379904jaddx9h0f74n32pjtmp6"
   },
   {


### PR DESCRIPTION
Re-enables APY for chains with a correct calculation. Still disabled for some chains like Stargaze (#453) as we can't calculate APR for them at all (usually missing mint endpoints).