### PR TITLE
Add MEME Network

### DIFF
--- a/src/networks.json
+++ b/src/networks.json
@@ -172,5 +172,9 @@
       "high": 0.04
     },
     "apyEnabled": false
+  },
+  {
+    "name": "meme",
+    "gasPrice": "0.025umeme"
   }
 ]


### PR DESCRIPTION
Adds network.json entry for MEME network. I wasn't sure if the `gasPrice` was required or not--it seemed to work fine with it or grabbing it from cosmos.directory. I went ahead and added it since most other chains had it.

I've tested this locally, but found no unit tests to expand or update.