### PR TITLE
Enable all networks

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -119,7 +119,7 @@ class App extends React.Component {
       } catch (e) {
         console.log(e)
         return this.setState({
-          error: 'Failed to connect to signing client. API may be down.',
+          error: 'Failed to connect to signing client: ' + e.message,
           loading: false
         })
       }

--- a/src/components/Delegations.js
+++ b/src/components/Delegations.js
@@ -663,18 +663,14 @@ class Delegations extends React.Component {
     const alerts = (
       <>
         {!this.authzSupport() && (
-          <AlertMessage variant="warning" dismissible={false}>
-            {this.props.network.prettyName} doesn't support Authz just yet. You
-            can manually restake for now and REStake is ready when support is
-            enabled
+          <AlertMessage variant="info" dismissible={false}>
+            {this.props.network.prettyName} doesn't support Authz just yet. You can stake and compound manaully for now and REStake will update automatically when support is added.
           </AlertMessage>
         )}
-        {this.authzSupport() && !this.props.operators.length && (
-          <AlertMessage
-            variant="warning"
-            message="There are no REStake operators for this network yet. You can compound manually, or check the About section to run one yourself"
-            dismissible={false}
-          />
+        {this.props.network.experimental && (
+          <AlertMessage variant="info" dismissible={false}>
+            This network was added to REStake automatically and has not been thoroughly tested yet. <a href="https://github.com/eco-stake/restake/issues" target="_blank">Raise an issue</a> if you have any problems.
+          </AlertMessage>
         )}
         {this.authzSupport() &&
           this.props.operators.length > 0 &&

--- a/src/components/NetworkFinder.js
+++ b/src/components/NetworkFinder.js
@@ -113,7 +113,7 @@ function NetworkFinder() {
       let networkName = params.network || defaultNetwork.name
       let data = state.networks[networkName]
       if(params.network && !data){
-        networkName = Object.keys(state.networks)[0]
+        networkName = defaultNetwork.name
         data = state.networks[networkName]
       }
       if(!data){

--- a/src/components/NetworkFinder.js
+++ b/src/components/NetworkFinder.js
@@ -41,11 +41,16 @@ function NetworkFinder() {
       return {}
     }
 
-    const networks = networksData.filter(el => el.enabled !== false).map(data => {
-      const registryData = registryNetworks[data.name] || {}
-      return {...registryData, ...data}
+    const networks = Object.values(registryNetworks).map(data => {
+      const networkData = networksData.find(el => el.name === data.path)
+      if(networkData && networkData.enabled === false) return 
+      if(!data.image) return
+
+      if(!networkData) data.experimental = true
+
+      return {...data, ...networkData}
     })
-    return _.compact(networks).reduce((a, v) => ({ ...a, [v.name]: v}), {})
+    return _.compact(networks).reduce((a, v) => ({ ...a, [v.path]: v}), {})
   }
 
   const changeNetwork = (network) => {

--- a/src/components/NetworkFinder.js
+++ b/src/components/NetworkFinder.js
@@ -108,7 +108,9 @@ function NetworkFinder() {
 
   useEffect(() => {
     if(Object.keys(state.networks).length && !state.network){
-      let networkName = params.network || Object.keys(state.networks)[0]
+      const networks = Object.values(state.networks)
+      const defaultNetwork = (networks.find(el => el.default === true) || networks[0])
+      let networkName = params.network || defaultNetwork.name
       let data = state.networks[networkName]
       if(params.network && !data){
         networkName = Object.keys(state.networks)[0]

--- a/src/components/NetworkSelect.js
+++ b/src/components/NetworkSelect.js
@@ -56,7 +56,7 @@ function NetworkSelect(props) {
       const network = new Network(data);
       network.load().then(() => {
         setSelectedNetwork(network);
-        if (network.usingDirectory && !directoryConnected(data)) {
+        if (network.usingDirectory && !network.directoryConnected) {
           throw false;
         }
         return network.connect().then(() => {
@@ -73,11 +73,6 @@ function NetworkSelect(props) {
         setLoading(false);
       });
     }
-  }
-
-  function directoryConnected(data) {
-    // replace with available status when added to directory
-    return ['rpc', 'rest'].every(type => data['best_apis'][type].length > 0)
   }
 
   function renderCheck({ title, failTitle, description, failDescription, state, successClass, failClass, identifier }){
@@ -123,7 +118,7 @@ function NetworkSelect(props) {
           image: el.image,
           operatorCount: el.operators?.length || operatorCounts[el.name],
           authz: el.params?.authz,
-          online: !network.usingDirectory || directoryConnected(el),
+          online: !network.usingDirectory || network.directoryConnected,
           experimental: network.experimental
         }
       }),
@@ -199,15 +194,15 @@ function NetworkSelect(props) {
                 </div>
               }
               <ul className="list-group">
-                {renderCheck({
-                  title: 'API connected',
-                  failTitle: 'API offline',
-                  failDescription: error,
-                  state: !error,
-                  failClass: 'danger',
-                  identifier: 'network'
-                })}
-                {!error && ([
+                {([
+                  renderCheck({
+                    title: 'API connected',
+                    failTitle: 'API offline',
+                    failDescription: error,
+                    state: selectedNetwork.connected && !error,
+                    failClass: 'danger',
+                    identifier: 'network'
+                  }),
                   renderCheck({
                     title: 'Authz support',
                     failTitle: 'No Authz support',

--- a/src/components/NetworkSelect.js
+++ b/src/components/NetworkSelect.js
@@ -2,6 +2,7 @@ import React, { useState, useReducer, useEffect } from 'react';
 
 import CosmosDirectory from '../utils/CosmosDirectory.mjs';
 import Network from '../utils/Network.mjs'
+import TooltipIcon from './TooltipIcon.js';
 
 import {
   Button,
@@ -9,6 +10,8 @@ import {
   Form,
   Badge
 } from 'react-bootstrap'
+
+import { CheckCircle, XCircle } from "react-bootstrap-icons";
 
 import Select from 'react-select';
 
@@ -66,7 +69,7 @@ function NetworkSelect(props) {
         });
       }).catch(error => {
         console.log(error);
-        setError('Unable to connect to this network currently. Try again later.');
+        setError('Could not connect to this network. Try again later');
         setLoading(false);
       });
     }
@@ -76,6 +79,30 @@ function NetworkSelect(props) {
     // replace with available status when added to directory
     return ['rpc', 'rest'].every(type => data['best_apis'][type].length > 0)
   }
+
+  function renderCheck({ title, failTitle, description, failDescription, state, successClass, failClass, identifier }){
+    const className = state ? (successClass || 'success') : (failClass || 'warning')
+
+    const content = (
+      <div>
+        {state ? (
+          <CheckCircle className="me-2 mb-1" />
+        ) : (
+          <XCircle className="me-2 mb-1" />
+        )}{state ? title : (failTitle || title)}
+      </div>
+    )
+    
+    return (
+      <li key={identifier} className={`list-group-item list-group-item-${className}`}>
+        <TooltipIcon
+          icon={content}
+          identifier={identifier}
+          tooltip={state ? description : (failDescription || description)}
+        />
+      </li>
+    )
+  b}
 
   useEffect(() => {
     if (props.show && !show) {
@@ -96,17 +123,11 @@ function NetworkSelect(props) {
           image: el.image,
           operatorCount: el.operators?.length || operatorCounts[el.name],
           authz: el.params?.authz,
-          online: !network.usingDirectory || directoryConnected(el)
+          online: !network.usingDirectory || directoryConnected(el),
+          experimental: network.experimental
         }
       }),
-      network: selectedNetwork && {
-        value: selectedNetwork.name,
-        label: selectedNetwork.prettyName,
-        image: selectedNetwork.image,
-        operatorCount: selectedNetwork.operators?.length,
-        authz: selectedNetwork.authzSupport,
-        online: true // modal will show status
-      }
+      network: selectedNetwork && selectedNetwork.name
     })
   }, [props.networks, selectedNetwork, operatorCounts])
 
@@ -140,7 +161,7 @@ function NetworkSelect(props) {
                 <div className="row mb-3">
                   <div className="col">
                     <Select
-                      value={options.network}
+                      value={options.networks.find(el => el.value === options.network)}
                       isClearable={false}
                       name="network"
                       options={options.networks}
@@ -158,8 +179,8 @@ function NetworkSelect(props) {
                               <small>{network.operatorCount} Operator{network.operatorCount > 1 ? 's' : ''}</small>
                             }
                             {network.authz
-                              ? <Badge className="ms-3 rounded-pill" bg="success">Authz</Badge>
-                              : <Badge className="ms-3 rounded-pill text-decoration-line-through" bg="danger">Authz</Badge>
+                              ? <Badge className={`ms-3 rounded-pill` + (!network.online ? ' opacity-50' : '')} bg="success">Authz</Badge>
+                              : <Badge className={`ms-3 rounded-pill text-decoration-line-through` + (!network.online ? ' opacity-50' : '')} bg="danger">Authz</Badge>
                             }
                           </div>
                         </div>
@@ -177,23 +198,49 @@ function NetworkSelect(props) {
                   </div>
                 </div>
               }
-              {error &&
-                <p><em>{error}</em></p>
-              }
-              {!error && !selectedNetwork.authzSupport &&
-                <p><em>This network does not support Authz yet. You can manually stake and compound for now</em></p>
-              }
-              {!error && selectedNetwork.authzSupport && selectedNetwork.operators?.length < 1 &&
-                <p><em>This network supports Authz but there are no operators just yet. You can manually REStake for now</em></p>
-              }
-              {!loading
-                ? !error && <Button type="submit" className="btn btn-primary">Change</Button>
-                : (
-                  <Button className="btn-sm btn-primary mr-5" disabled>
-                    <span className="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>&nbsp;
-                    Updating...
-                  </Button>
-                )}
+              <ul className="list-group">
+                {renderCheck({
+                  title: 'API connected',
+                  failTitle: 'API offline',
+                  failDescription: error,
+                  state: !error,
+                  failClass: 'danger',
+                  identifier: 'network'
+                })}
+                {!error && ([
+                  renderCheck({
+                    title: 'Authz support',
+                    failTitle: 'No Authz support',
+                    failDescription: "This network doesn't support Authz just yet. You can stake and compound manaully for now and REStake will update automatically when support is added.",
+                    state: selectedNetwork.authzSupport,
+                    identifier: 'authz'
+                  }),
+                  renderCheck({
+                    title: <span><strong>{selectedNetwork.operators?.length}</strong> REStake operators</span>,
+                    failTitle: "No REStake operators",
+                    failDescription: "There are no operators for this network yet. You can stake and compound manually in the meantime.",
+                    state: selectedNetwork.operators?.length > 0,
+                    identifier: 'operators'
+                  }),
+                  renderCheck({
+                    title: 'Tested with REStake',
+                    failTitle: 'Not tested with REStake',
+                    failDescription: "This network was added to REStake automatically and has not been thoroughly tested yet.",
+                    state: selectedNetwork.operators?.length > 0,
+                    identifier: 'experimental'
+                  })
+                ])}
+              </ul>
+              <div className="text-center mt-4 mb-2">
+                {!loading
+                  ? !error && <Button type="submit" className="btn btn-primary btn-lg">Change network</Button>
+                  : (
+                    <Button className="btn-primary btn-lg mr-5" disabled>
+                      <span className="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>&nbsp;
+                      Updating...
+                    </Button>
+                  )}
+              </div>
             </Form>
           }
         </Modal.Body>

--- a/src/components/TooltipIcon.js
+++ b/src/components/TooltipIcon.js
@@ -4,7 +4,6 @@ import {
 } from 'react-bootstrap'
 
 function TooltipIcon(props) {
-
   return (
     <>
       {(props.children || props.tooltip) ? (

--- a/src/networks.json
+++ b/src/networks.json
@@ -2,7 +2,8 @@
   {
     "name": "osmosis",
     "gasPrice": "0.0025uosmo",
-    "ownerAddress": "osmovaloper1u5v0m74mql5nzfx2yh43s2tke4mvzghr6m2n5t"
+    "ownerAddress": "osmovaloper1u5v0m74mql5nzfx2yh43s2tke4mvzghr6m2n5t",
+    "default": true
   },
   {
     "name": "juno",

--- a/src/utils/Network.mjs
+++ b/src/utils/Network.mjs
@@ -17,7 +17,7 @@ class Network {
     this.enabled = data.enabled
     this.experimental = data.experimental
     this.apyEnabled = data.apyEnabled
-    this.name = data.name
+    this.name = data.path || data.name
     this.default = data.default
     this.directory = CosmosDirectory()
 

--- a/src/utils/Network.mjs
+++ b/src/utils/Network.mjs
@@ -18,6 +18,7 @@ class Network {
     this.experimental = data.experimental
     this.apyEnabled = data.apyEnabled
     this.name = data.name
+    this.default = data.default
     this.directory = CosmosDirectory()
 
     this.rpcUrl = data.rpcUrl || this.directory.rpcUrl(data.name)

--- a/src/utils/Network.mjs
+++ b/src/utils/Network.mjs
@@ -15,6 +15,7 @@ class Network {
 
     this.data = data
     this.enabled = data.enabled
+    this.experimental = data.experimental
     this.apyEnabled = data.apyEnabled
     this.name = data.name
     this.directory = CosmosDirectory()

--- a/src/utils/Network.mjs
+++ b/src/utils/Network.mjs
@@ -32,6 +32,7 @@ class Network {
         return match(el)
       }
     })
+    this.directoryConnected = ['rpc', 'rest'].every(type => data['best_apis'][type].length > 0)
   }
 
   async load() {
@@ -62,7 +63,7 @@ class Network {
       this.queryClient = await QueryClient(this.chain.chainId, this.rpcUrl, this.restUrl)
       this.restUrl = this.queryClient.restUrl
       this.rpcUrl = this.queryClient.rpcUrl
-      this.connected = this.queryClient.connected
+      this.connected = this.queryClient.connected && (!this.usingDirectory || this.directoryConnected)
     } catch (error) {
       console.log(error)
       this.connected = false


### PR DESCRIPTION
This PR enables all networks in the Chain Registry on REStake automatically. Networks that are not defined in `networks.json` will show a warning stating they have not been fully tested and to raise an issue if they have problems.

There is enough information sourced from chain registry for this to work now. It allows REStake to be a platform both chains and validators can use autonomously. It encourages keeping Chain Registry up to date, and networks can be disabled if needed via `networks.json`.

This PR also resolves #232 by allowing `networks.json` to define the default network when loading the site. This will be improved later with #469.

Resolves #373, improves the network select with status for the chain, and improves connection logic