### PR TITLE
Gas usage optimization

### DIFF
--- a/scripts/base.mjs
+++ b/scripts/base.mjs
@@ -309,12 +309,6 @@ export class Autostake {
 
   buildRestakeMessage(address, validatorAddress, amount, denom) {
     return [{
-      typeUrl: "/cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward",
-      value: MsgWithdrawDelegatorReward.encode(MsgWithdrawDelegatorReward.fromPartial({
-        delegatorAddress: address,
-        validatorAddress: validatorAddress
-      })).finish()
-    }, {
       typeUrl: "/cosmos.staking.v1beta1.MsgDelegate",
       value: MsgDelegate.encode(MsgDelegate.fromPartial({
         delegatorAddress: address,


### PR DESCRIPTION
I would like to propose a change that might slightly optimize gas usage by reducing the number of messages in a transaction. It is not necessary to collect the rewards first and then make the delegation, it is just enough to delegate.

Pros: reduced costs for validators who serve a large number of delegators.
Cons: the transaction becomes less informative. It may not be clear from which funds the delegation comes. Often explorers have an "auto claim rewards" field, which partially resolves this problem.

Examples:
1) [Get reward + delegate (current implementation)](https://explorer.yummy.capital/txs/33FEF1A65ADFCDE1D7F93F9D91B2E3FE95940600269E58BC2A8B9B763B57FBFC)
2) [Delegate only (current propose)](https://explorer.yummy.capital/txs/55757468E060F16BD1B1E27C0AD7BD20A7B713FFFE3F5D75A4AFB0E0B49393FB)