### PR TITLE
Reduce Regen TX batch size (open to feedback)

### DIFF
--- a/src/networks.json
+++ b/src/networks.json
@@ -29,7 +29,10 @@
   {
     "name": "regen",
     "gasPrice": "0.03uregen",
-    "ownerAddress": "regenvaloper1c4y3j05qx652rnxm5mg4yesqdkmhz2f6dl7hhk"
+    "ownerAddress": "regenvaloper1c4y3j05qx652rnxm5mg4yesqdkmhz2f6dl7hhk",
+    "autostake": {
+      "batchTxs": 5
+    }
   },
   {
     "name": "terra",


### PR DESCRIPTION
I've been having problems with 9 txs in one batch, reducing to 5 fixed it. If this is an issue for all Regen operators then it's better to solve in `networks.json` rather than my `networks.local.json`.