### PR TITLE
Add configurable gas modifier, default to 1.1/1.25

### DIFF
--- a/scripts/base.mjs
+++ b/scripts/base.mjs
@@ -284,7 +284,9 @@ export class Autostake {
         try {
           timeStamp('...batch', index + 1)
           const memo = 'REStaked by ' + client.operator.moniker
-          await client.signingClient.signAndBroadcast(client.operator.botAddress, batch, undefined, memo).then((result) => {
+          const gasModifier = client.network.data.autostake?.gasModifier || 1.1
+          const gas = await client.signingClient.simulate(client.operator.botAddress, batch, memo, gasModifier);
+          await client.signingClient.signAndBroadcast(client.operator.botAddress, batch, gas, memo).then((result) => {
             timeStamp("Successfully broadcasted");
           }, (error) => {
             client.health.error('Failed to broadcast:', error.message)

--- a/src/utils/DesmosSigningClient.mjs
+++ b/src/utils/DesmosSigningClient.mjs
@@ -1,8 +1,8 @@
 import { profileFromAny } from "@desmoslabs/desmjs";
 import SigningClient from "./SigningClient.mjs";
 
-function DesmosSigningClient(rpcUrl, defaultGasPrice, signer, key) {
-  return SigningClient(rpcUrl, defaultGasPrice, signer, key, {
+function DesmosSigningClient(rpcUrl, defaultGasPrice, gasModifier, signer, key) {
+  return SigningClient(rpcUrl, defaultGasPrice, gasModifier, signer, key, {
     accountParser: profileFromAny,
   })
 }

--- a/src/utils/Network.mjs
+++ b/src/utils/Network.mjs
@@ -60,6 +60,7 @@ class Network {
     this.gasPrice = this.data.gasPrice || defaultGasPrice
     this.gasPriceStep = this.data.gasPriceStep
     this.gasPricePrefer = this.data.gasPricePrefer
+    this.gasModifier = this.data.gasModifier || 1.25
   }
 
   async connect() {
@@ -97,7 +98,7 @@ class Network {
       return
 
     const client = this.SIGNERS[this.name] || SigningClient
-    return client(this.queryClient.rpcUrl, gasPrice || this.gasPrice, wallet, key)
+    return client(this.queryClient.rpcUrl, gasPrice || this.gasPrice, this.gasModifier, wallet, key)
   }
 
   getOperator(operatorAddress) {

--- a/src/utils/SigningClient.mjs
+++ b/src/utils/SigningClient.mjs
@@ -7,7 +7,7 @@ import {
 import { multiply, ceil, bignumber } from 'mathjs'
 import { coin } from './Helpers.mjs'
 
-async function SigningClient(rpcUrl, defaultGasPrice, signer, key, signerOpts) {
+async function SigningClient(rpcUrl, defaultGasPrice, defaultGasModifier, signer, key, signerOpts) {
 
   const client = rpcUrl && await SigningStargateClient.connectWithSigner(
     rpcUrl,
@@ -78,7 +78,7 @@ async function SigningClient(rpcUrl, defaultGasPrice, signer, key, signerOpts) {
 
   async function simulate(address, msgs, memo, modifier) {
     const estimate = await client.simulate(address, msgs, memo);
-    return (parseInt(estimate * (modifier || 1.5)));
+    return (parseInt(estimate * (modifier || defaultGasModifier)));
   }
 
   return {


### PR DESCRIPTION
Changes the default gas modifier. Previously 1.5x, now 1.25x in UI and 1.1x for autostaking. 

Autostaking will be ~25% cheaper than before.

Adds two new network configuration options to further tweak this. There is still a bit of room to reduce 1.1 further but it could be less reliable.

```
{
  "akash": {
    "gasModifier": 1.25,
    "autostake": {
      "gasModifier": 1.1
    }
}
```

Resolves #481 