### PR TITLE
Autostake allow any chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,10 +89,10 @@ Note you might need `sudo` depending on your docker install.
 docker-compose run --rm app npm run autostake
 ```
 
-Pass a network name to run the script for a single network at a time.
+Pass network names to restrict the script to certain networks.
 
 ```bash
-docker-compose run --rm app npm run autostake osmosis
+docker-compose run --rm app npm run autostake osmosis akash regen
 ```
 
 ### Updating your local version

--- a/scripts/autostake.mjs
+++ b/scripts/autostake.mjs
@@ -1,5 +1,5 @@
 import { Autostake } from "./base.mjs";
 
 const autostake = new Autostake();
-const networkName = process.argv[2]
+const networkName = process.argv.slice(2, process.argv.length)
 autostake.run(networkName)

--- a/scripts/base.mjs
+++ b/scripts/base.mjs
@@ -24,12 +24,14 @@ export class Autostake {
     }
   }
 
-  async run(networkName){
+  async run(networkNames){
     const networks = this.getNetworksData()
-    if(networkName && !networks.map(el => el.name).includes(networkName)) return timeStamp('Invalid network name:', networkName)
+    for(const name of networkNames){
+      if (name && !networks.map(el => el.name).includes(name)) return timeStamp('Invalid network name:', name)
+    }
     const calls = networks.map(data => {
       return async () => {
-        if(networkName && data.name !== networkName) return
+        if(networkNames && !networkNames.includes(data.name)) return
         if(data.enabled === false) return
 
         let client

--- a/scripts/base.mjs
+++ b/scripts/base.mjs
@@ -94,7 +94,11 @@ export class Autostake {
   async getClient(data, health) {
     let network = new Network(data)
     let slip44
-    await network.load()
+    try {
+      await network.load()
+    } catch {
+      return timeStamp('Unable to load network data for', network.name)
+    }
 
     timeStamp('Starting', network.prettyName)
 
@@ -348,16 +352,12 @@ export class Autostake {
   getNetworksData() {
     const networksData = fs.readFileSync('src/networks.json');
     const networks = JSON.parse(networksData);
-    const networkNames = networks.map(el => el.name)
     try {
       const overridesData = fs.readFileSync('src/networks.local.json');
       const overrides = overridesData && JSON.parse(overridesData) || {}
-      Object.keys(overrides).forEach(key => {
-        if(!networkNames.includes(key)) timeStamp('Invalid key in networks.local.json:', key)
-      })
       return overrideNetworks(networks, overrides)
-    } catch {
-      timeStamp('Failed to parse networks.local.json, check JSON is valid')
+    } catch (error) {
+      timeStamp('Failed to parse networks.local.json, check JSON is valid', error.message)
       return networks
     }
   }

--- a/src/utils/Helpers.mjs
+++ b/src/utils/Helpers.mjs
@@ -11,8 +11,12 @@ export function coin(amount, denom){
 }
 
 export function overrideNetworks(networks, overrides){
-  return networks.map(network => {
-    let override = overrides[network.name]
+  networks = networks.reduce((a, v) => ({ ...a, [v.name]: v }), {})
+  const names = [...Object.keys(networks), ...Object.keys(overrides)]
+  return names.map(name => {
+    let network = networks[name]
+    let override = overrides[name]
+    if(!network || !network.name) network = { name, ...network }
     if(!override) return network
     override.overriden = true
     return _.mergeWith(network, override, (a, b) =>

--- a/src/utils/Helpers.mjs
+++ b/src/utils/Helpers.mjs
@@ -13,7 +13,7 @@ export function coin(amount, denom){
 export function overrideNetworks(networks, overrides){
   networks = networks.reduce((a, v) => ({ ...a, [v.name]: v }), {})
   const names = [...Object.keys(networks), ...Object.keys(overrides)]
-  return names.map(name => {
+  return _.uniq(names).sort().map(name => {
     let network = networks[name]
     let override = overrides[name]
     if(!network || !network.name) network = { name, ...network }


### PR DESCRIPTION
Allows operators to autostake for experimental/chain registry chains. Previously you had to adjust networks.json to make this work.

Still requires a `networks.local.json` inclusion, but doesn't need any data:

```
{
  "provenance": {},
  "osmosis": {
    ...
  }
}
```

Also sorts the autostaking list when running it with no network argument.

Resolves #479 

Additionally allows passing multiple network names when autostaking, e.g. `npm run autostake osmosis akash regen`. Resolves #199 