### PR TITLE
Add Bostrom Rest and RPC instead of default

### DIFF
--- a/src/networks.json
+++ b/src/networks.json
@@ -144,6 +144,12 @@
   },
   {
     "name": "bostrom",
+    "restUrl": [
+      "https://lcd.bostrom.cybernode.ai/"
+    ],
+    "rpcUrl": [
+      "https://rpc.bostrom.cybernode.ai/"
+    ],
     "gasPrice": "0boot"
   },
   {


### PR DESCRIPTION
Add Bostrom REST and RPC instead of the standard one due to incorrect work
- REST: https://rest.cosmos.directory/bostrom -> https://lcd.bostrom.cybernode.ai/
- RPC: https://rpc.cosmos.directory/bostrom -> https://rpc.bostrom.cybernode.ai/

The correct APIs are taken from the official repository https://github.com/cybercongress/go-cyber#setup