### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "start": "npx parcel src/index.html",
     "prebuild": "rm -rf dist/",
     "build": "npx parcel build src/index.html",
-    "autostake": "NODE_OPTIONS=--openssl-legacy-provider node scripts/autostake.mjs"
+    "autostake": "node scripts/autostake.mjs"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
`NODE_OPTIONS=--openssl-legacy-provider` 
produces error:
`node: --openssl-legacy-provider is not allowed in NODE_OPTIONS`
at least on node 16.X (Current LTS)