### PR TITLE
Autostake batch msg exec

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "start": "npx parcel src/index.html",
     "prebuild": "rm -rf dist/",
     "build": "npx parcel build src/index.html",
+    "dryrun": "NODE_OPTIONS=--openssl-legacy-provider node scripts/dryrun.mjs",
     "autostake": "NODE_OPTIONS=--openssl-legacy-provider node scripts/autostake.mjs"
   },
   "eslintConfig": {

--- a/scripts/base.mjs
+++ b/scripts/base.mjs
@@ -298,9 +298,7 @@ export class Autostake {
 
     timeStamp(address, "Can autostake", autostakeAmount, client.network.denom)
 
-    let messages = this.buildRestakeMessage(address, client.operator.address, autostakeAmount, client.network.denom)
-
-    return this.buildExecMessage(client.operator.botAddress, messages)
+    return this.buildRestakeMessage(address, client.operator.address, autostakeAmount, client.network.denom)
   }
 
   async autostake(client, messages) {
@@ -313,13 +311,14 @@ export class Autostake {
       return async () => {
         try {
           timeStamp('...batch', index + 1)
+          const execMsg = this.buildExecMessage(client.operator.botAddress, batch)
           const memo = 'REStaked by ' + client.operator.moniker
           const gasModifier = client.network.data.autostake?.gasModifier || 1.1
-          const gas = await client.signingClient.simulate(client.operator.botAddress, batch, memo, gasModifier);
+          const gas = await client.signingClient.simulate(client.operator.botAddress, [execMsg], memo, gasModifier);
           if(this.opts.dryRun){
             timeStamp("DRYRUN: Would autostake", batch.length, "TXs using", gas, "gas")
           }else{
-            await client.signingClient.signAndBroadcast(client.operator.botAddress, batch, gas, memo).then((result) => {
+            await client.signingClient.signAndBroadcast(client.operator.botAddress, [execMsg], gas, memo).then((result) => {
               timeStamp("Successfully broadcasted");
             }, (error) => {
               client.health.error('Failed to broadcast:', error.message)

--- a/src/utils/AutostakeHealth.mjs
+++ b/src/utils/AutostakeHealth.mjs
@@ -3,11 +3,12 @@ import axios from 'axios'
 import { timeStamp } from './Helpers.mjs'
 
 class AutostakeHealth {
-  constructor(config) {
+  constructor(config, opts) {
     const { address, uuid } = config || {}
+    const { dryRun } = opts || {}
     this.address = address || 'https://hc-ping.com'
     this.uuid = uuid
-    this.config = config
+    this.dryRun = dryRun
   }
 
   started(...args){
@@ -42,6 +43,7 @@ class AutostakeHealth {
 
   ping(action, ...args){
     if(!this.uuid) return
+    if(this.dryRun) timeStamp('DRYRUN: Skipping health check ping')
 
     axios.request({
       method: 'POST',


### PR DESCRIPTION
The script will now send a single MsgExec for each batch, with each message nested inside. Rather than a batch of individual MsgExecs.

This doesn't make much difference to gas but it's cleaner and easier to parse. 

Resolves #515 