### PR TITLE
Add configurable throttle to autostake

### DIFF
--- a/src/autostake/index.mjs
+++ b/src/autostake/index.mjs
@@ -142,7 +142,8 @@ export default function Autostake(mnemonic, opts) {
 
     if (usingDirectory) {
       timeStamp('You are using public nodes, they may not be reliable. Check the README to use your own')
-      timeStamp('Delaying briefly to reduce load...')
+      timeStamp('Delaying briefly and adjusting config to reduce load...')
+      opts = {...opts, batchPageSize: 50, batchQueries: 10, queryThrottle: 1000}
       await new Promise(r => setTimeout(r, (Math.random() * 31) * 1000));
     }
 

--- a/src/utils/Helpers.mjs
+++ b/src/utils/Helpers.mjs
@@ -112,7 +112,7 @@ export async function mapSync(calls, count, batchCallback) {
   for (const batchCall of batchCalls) {
     const batchResults = await mapAsync(batchCall, call => call())
     results.push(batchResults)
-    if (batchCallback) batchCallback(batchResults, index)
+    if (batchCallback) await batchCallback(batchResults, index)
     index++
   }
   return results.flat()

--- a/src/utils/QueryClient.mjs
+++ b/src/utils/QueryClient.mjs
@@ -137,7 +137,7 @@ const QueryClient = async (chainId, restUrls) => {
       .then((res) => res.data)
   };
 
-  const getGranteeGrants = (grantee, opts) => {
+  const getGranteeGrants = (grantee, opts, pageCallback) => {
     const { pageSize } = opts || {}
     return getAllPages((nextKey) => {
       const searchParams = new URLSearchParams();
@@ -148,12 +148,12 @@ const QueryClient = async (chainId, restUrls) => {
         .get(restUrl + "/cosmos/authz/v1beta1/grants/grantee/" + grantee + "?" +
           searchParams.toString(), opts)
         .then((res) => res.data)
-    }).then((pages) => {
+    }, pageCallback).then((pages) => {
       return pages.map(el => el.grants).flat();
     });
   };
 
-  const getGranterGrants = (granter, opts) => {
+  const getGranterGrants = (granter, opts, pageCallback) => {
     const { pageSize } = opts || {}
     return getAllPages((nextKey) => {
       const searchParams = new URLSearchParams();
@@ -164,7 +164,7 @@ const QueryClient = async (chainId, restUrls) => {
         .get(restUrl + "/cosmos/authz/v1beta1/grants/granter/" + granter + "?" +
           searchParams.toString(), opts)
         .then((res) => res.data)
-    }).then((pages) => {
+    }, pageCallback).then((pages) => {
       return pages.map(el => el.grants).flat();
     });
   };
@@ -202,7 +202,7 @@ const QueryClient = async (chainId, restUrls) => {
       const result = await getPage(nextKey);
       pages.push(result);
       nextKey = result.pagination.next_key;
-      if (pageCallback) pageCallback(pages);
+      if (pageCallback) await pageCallback(pages);
     } while (nextKey);
     return pages;
   };


### PR DESCRIPTION
Adds a configurable throttle to autostake which pauses the script after each page/batch of queries completes to reduce the pressure on the node slightly. Defaults to 100ms, and doesn't impact the get rewards/send in batches flow as this would increase the delay between calculating rewards and the TX being sent, leaving the user with increasing dust.

This PR also **forces a higher throttle and smaller batch/page sizes when using the default public nodes** for autostake. This shouldn't impact small validators much, but larger validators or those that run very often might have some issues and should run their own nodes to remove these limitations.

Tidies up the autostake configuration implementation and makes the config more visible.

Resolves #364 