### PR TITLE
Add timeout option for availableUrl check

### DIFF
--- a/src/autostake/NetworkRunner.mjs
+++ b/src/autostake/NetworkRunner.mjs
@@ -11,7 +11,7 @@ export default class NetworkRunner {
     this.operator = operator
     this.signingClient = signingClient
     this.queryClient = network.queryClient
-    this.opts = {
+    this.opts = _.merge({
       batchPageSize: 100,
       batchQueries: 25,
       batchTxs: 50,
@@ -19,9 +19,7 @@ export default class NetworkRunner {
       queryTimeout: network.data.autostake?.delegatorTimeout || 5000, // deprecate delegatorTimeout
       queryThrottle: 100,
       gasModifier: 1.1,
-      ...network.data.autostake,
-      ...opts
-    }
+    }, network.data.autostake, opts)
     this.batch = {}
     this.messages = []
     this.processed = {}

--- a/src/autostake/index.mjs
+++ b/src/autostake/index.mjs
@@ -132,7 +132,7 @@ export default function Autostake(mnemonic, opts) {
 
     if (!network.authzSupport) return timeStamp('No Authz support')
 
-    await network.connect()
+    await network.connect({ timeout: opts.delegationsTimeout || 20000 })
 
     const { restUrl, usingDirectory } = network
 

--- a/src/utils/Network.mjs
+++ b/src/utils/Network.mjs
@@ -102,9 +102,9 @@ class Network {
     this.txTimeout = this.data.txTimeout || 60_000
   }
 
-  async connect() {
+  async connect({ timeout }) {
     try {
-      this.queryClient = await QueryClient(this.chain.chainId, this.restUrl)
+      this.queryClient = await QueryClient(this.chain.chainId, this.restUrl, { connectTimeout: timeout })
       this.restUrl = this.queryClient.restUrl
       this.connected = this.queryClient.connected && (!this.usingDirectory || this.connectedDirectory())
     } catch (error) {

--- a/src/utils/QueryClient.mjs
+++ b/src/utils/QueryClient.mjs
@@ -1,8 +1,11 @@
 import axios from "axios";
 import _ from "lodash";
 
-const QueryClient = async (chainId, restUrls) => {
-  let restUrl = await findAvailableUrl(restUrls, "rest")
+const QueryClient = async (chainId, restUrls, opts) => {
+  const config = _.merge({
+    connectTimeout: 10000,
+  }, opts)
+  const restUrl = await findAvailableUrl(restUrls, "rest", { timeout: config.connectTimeout })
 
   const getAllValidators = (pageSize, opts, pageCallback) => {
     return getAllPages((nextKey) => {
@@ -209,7 +212,7 @@ const QueryClient = async (chainId, restUrls) => {
     return pages;
   };
 
-  async function findAvailableUrl(urls, type) {
+  async function findAvailableUrl(urls, type, { timeout }) {
     if(!urls) return
 
     if (!Array.isArray(urls)) {
@@ -223,7 +226,7 @@ const QueryClient = async (chainId, restUrls) => {
     return Promise.any(urls.map(async (url) => {
       url = url.replace(/\/$/, '')
       try {
-        let data = await axios.get(url + path, { timeout: 10000 })
+        let data = await axios.get(url + path, { timeout })
           .then((res) => res.data)
         if (type === "rpc") data = data.result;
         if (data.block?.header?.chain_id === chainId) {


### PR DESCRIPTION
Respects `delegatorTimeout` for the availableUrl check in autostake when using custom restUrls. This was fixed to 10s previously, now defaults to 20s.