### PR TITLE
Disable Osmosis amino authz MsgExec

### DIFF
--- a/src/components/AboutLedger.js
+++ b/src/components/AboutLedger.js
@@ -10,7 +10,7 @@ function AboutLedger(props) {
   const aboutParam = searchParams.get('about')
 
   const { network, validator } = props
-  const { daemon_name, chain_id, node_home, codebase } = network.chain.data
+  const { daemon_name, chain_id, node_home, codebase } = network.chain
   const { git_repo, binaries } = codebase || {}
 
   const address = validator?.restake?.address || <kbd>GrantAddress</kbd>

--- a/src/components/GrantModal.js
+++ b/src/components/GrantModal.js
@@ -26,7 +26,7 @@ function GrantModal(props) {
   const [state, setState] = useState({ maxTokensValue: '', expiryDateValue: defaultExpiry.format('YYYY-MM-DD') });
   const [showLedger, setShowLedger] = useState(!walletAuthzSupport)
 
-  const { daemon_name, chain_id } = network.chain.data
+  const { daemon_name, chain_id } = network.chain
 
   useEffect(() => {
     setState({

--- a/src/networks.json
+++ b/src/networks.json
@@ -5,7 +5,8 @@
     "ownerAddress": "osmovaloper1u5v0m74mql5nzfx2yh43s2tke4mvzghr6m2n5t",
     "default": true,
     "maxPerDay": 1,
-    "authzAminoSupport": true
+    "authzAminoSupport": true,
+    "authzAminoExecSupport": false
   },
   {
     "name": "juno",

--- a/src/utils/Chain.mjs
+++ b/src/utils/Chain.mjs
@@ -5,6 +5,7 @@ const Chain = (data) => {
   const baseAsset = assets[0]
 
   return {
+    ...data,
     prettyName: data.prettyName || data.pretty_name,
     chainId: data.chainId || data.chain_id,
     prefix: data.prefix || data.bech32_prefix,
@@ -12,17 +13,15 @@ const Chain = (data) => {
     estimatedApr: data.params?.calculated_apr,
     authzSupport: data.authzSupport ?? data.params?.authz,
     authzAminoSupport: data.authzAminoSupport ?? false,
+    authzAminoExecSupport: data.authzAminoExecSupport ?? data.authzAminoSupport ?? false,
     denom: data.denom || baseAsset?.base?.denom,
     display: data.display || baseAsset?.display?.denom,
     symbol: data.symbol || baseAsset?.symbol,
     decimals: data.decimals || baseAsset?.decimals,
     image: data.image || baseAsset?.image,
     coinGeckoId: baseAsset?.coingecko_id,
-    services: data.services,
-    explorers: data.explorers,
     assets,
-    baseAsset,
-    data
+    baseAsset
   }
 }
 

--- a/src/utils/Network.mjs
+++ b/src/utils/Network.mjs
@@ -40,7 +40,7 @@ class Network {
   }
 
   connectedDirectory() {
-    const proxy_status = this.chain ? this.chain.data['proxy_status'] : this.data['proxy_status']
+    const proxy_status = this.chain ? this.chain['proxy_status'] : this.data['proxy_status']
     return proxy_status && ['rest'].every(type => proxy_status[type])
   }
 
@@ -87,6 +87,7 @@ class Network {
     this.apyEnabled = data.apyEnabled !== false && !!this.estimatedApr && this.estimatedApr > 0
     this.authzSupport = this.chain.authzSupport
     this.authzAminoSupport = this.chain.authzAminoSupport
+    this.authzAminoExecSupport = this.chain.authzAminoExecSupport
     this.defaultGasPrice = this.decimals && format(bignumber(multiply(0.000000025, pow(10, this.decimals))), { notation: 'fixed', precision: 4}) + this.denom
     this.gasPrice = this.data.gasPrice || this.defaultGasPrice
     if(this.gasPrice){

--- a/src/utils/SigningClient.mjs
+++ b/src/utils/SigningClient.mjs
@@ -241,6 +241,10 @@ function SigningClient(network, signer) {
       if(message.typeUrl.startsWith('/cosmos.authz') && !network.authzAminoSupport){
         throw new Error('This chain does not support amino conversion for Authz messages')
       }
+      if(message.typeUrl === '/cosmos.authz.v1beta1.MsgExec' && !network.authzAminoExecSupport){
+        // Osmosis MsgExec is broken with Amino currently
+        throw new Error('This chain does not support amino conversion for Authz Exec messages')
+      }
       return aminoTypes.toAmino(message)
     })
   }


### PR DESCRIPTION
Osmosis throws an error when signing a MsgExec message using Amino. MsgGrant and MsgRevoke work fine so this PR just disables MsgExec with amino and forces that to use ProtoBuf. This shows a fairly unclear error in the UI for ledger devices, but it allows wallets with signDirect support to still use the MsgExec feature that was working prior to amino signing being enabled. 