### PR TITLE
Enable Osmosis authz amino exec gov support

### DIFF
--- a/src/networks.json
+++ b/src/networks.json
@@ -5,8 +5,7 @@
     "ownerAddress": "osmovaloper1u5v0m74mql5nzfx2yh43s2tke4mvzghr6m2n5t",
     "default": true,
     "maxPerDay": 1,
-    "authzAminoSupport": true,
-    "authzAminoExecSupport": false
+    "authzAminoSupport": true
   },
   {
     "name": "juno",

--- a/src/utils/SigningClient.mjs
+++ b/src/utils/SigningClient.mjs
@@ -241,13 +241,6 @@ function SigningClient(network, signer) {
       if(message.typeUrl.startsWith('/cosmos.authz') && !network.authzAminoSupport){
         throw new Error('This chain does not support amino conversion for Authz messages')
       }
-      if(message.typeUrl === '/cosmos.authz.v1beta1.MsgExec' && network.path === 'osmosis'){
-        // Osmosis MsgExec gov is broken with Amino currently
-        // See https://github.com/osmosis-labs/cosmos-sdk/pull/342
-        if(message.value.msgs.some(msg => msg.typeUrl.startsWith('/cosmos.gov'))){
-          throw new Error('Osmosis does not support amino conversion for Authz Exec gov messages')
-        }
-      }
       return aminoTypes.toAmino(message)
     })
   }


### PR DESCRIPTION
Pending a chain update fixing Authz amino MsgExec support for governance message types. Currently MsgExec throw a signature error and is disabled for Osmosis in REStake after #627 