### PR TITLE
Adjust Osmosis MsgExec amino limit

### DIFF
--- a/src/networks.json
+++ b/src/networks.json
@@ -5,8 +5,7 @@
     "ownerAddress": "osmovaloper1u5v0m74mql5nzfx2yh43s2tke4mvzghr6m2n5t",
     "default": true,
     "maxPerDay": 1,
-    "authzAminoSupport": true,
-    "authzAminoExecSupport": false
+    "authzAminoSupport": true
   },
   {
     "name": "juno",

--- a/src/utils/Chain.mjs
+++ b/src/utils/Chain.mjs
@@ -13,7 +13,6 @@ const Chain = (data) => {
     estimatedApr: data.params?.calculated_apr,
     authzSupport: data.authzSupport ?? data.params?.authz,
     authzAminoSupport: data.authzAminoSupport ?? false,
-    authzAminoExecSupport: data.authzAminoExecSupport ?? data.authzAminoSupport ?? false,
     denom: data.denom || baseAsset?.base?.denom,
     display: data.display || baseAsset?.display?.denom,
     symbol: data.symbol || baseAsset?.symbol,

--- a/src/utils/Network.mjs
+++ b/src/utils/Network.mjs
@@ -87,7 +87,6 @@ class Network {
     this.apyEnabled = data.apyEnabled !== false && !!this.estimatedApr && this.estimatedApr > 0
     this.authzSupport = this.chain.authzSupport
     this.authzAminoSupport = this.chain.authzAminoSupport
-    this.authzAminoExecSupport = this.chain.authzAminoExecSupport
     this.defaultGasPrice = this.decimals && format(bignumber(multiply(0.000000025, pow(10, this.decimals))), { notation: 'fixed', precision: 4}) + this.denom
     this.gasPrice = this.data.gasPrice || this.defaultGasPrice
     if(this.gasPrice){


### PR DESCRIPTION
Only prevent gov messages from signing with amino, all other types are fine