### PR TITLE
Amino authz improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "axios": "^0.26.0",
         "bootstrap": "^5.1.3",
         "buffer": "^6.0.3",
+        "compare-versions": "^5.0.1",
         "cosmjs-types": "^0.4.1",
         "dotenv": "^16.0.0",
         "fuzzy-search": "^3.2.1",
@@ -4382,6 +4383,11 @@
       "engines": {
         "node": ">= 10"
       }
+    },
+    "node_modules/compare-versions": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-5.0.1.tgz",
+      "integrity": "sha512-v8Au3l0b+Nwkp4G142JcgJFh1/TUhdxut7wzD1Nq1dyp5oa3tXaqb03EXOAB6jS4gMlalkjAUPZBMiAfKUixHQ=="
     },
     "node_modules/complex.js": {
       "version": "2.1.0",
@@ -11223,6 +11229,11 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
       "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
       "dev": true
+    },
+    "compare-versions": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-5.0.1.tgz",
+      "integrity": "sha512-v8Au3l0b+Nwkp4G142JcgJFh1/TUhdxut7wzD1Nq1dyp5oa3tXaqb03EXOAB6jS4gMlalkjAUPZBMiAfKUixHQ=="
     },
     "complex.js": {
       "version": "2.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1529,19 +1529,19 @@
       }
     },
     "node_modules/@keplr-wallet/common": {
-      "version": "0.11.3",
-      "resolved": "https://registry.npmjs.org/@keplr-wallet/common/-/common-0.11.3.tgz",
-      "integrity": "sha512-3izIyRX9nXTrc+u+24yYpl2qiLyHaweqiXI3fk2SHucWWicPqksSw5wkmuA+4Bef3/CUQPTgtcufDgPyBB+bNw==",
+      "version": "0.11.8",
+      "resolved": "https://registry.npmjs.org/@keplr-wallet/common/-/common-0.11.8.tgz",
+      "integrity": "sha512-HxOmmXT3oWb9rwZGAeZK57+NSh/qVBehV7EME8XjuvUkfV7NwCL8oZiNGfH8GZs22XoYoVXP8MCwEI7DKbLv1g==",
       "dependencies": {
-        "@keplr-wallet/crypto": "0.11.3",
+        "@keplr-wallet/crypto": "0.11.8",
         "buffer": "^6.0.3",
         "delay": "^4.4.0"
       }
     },
     "node_modules/@keplr-wallet/crypto": {
-      "version": "0.11.3",
-      "resolved": "https://registry.npmjs.org/@keplr-wallet/crypto/-/crypto-0.11.3.tgz",
-      "integrity": "sha512-BWSEU97qBu2M7DmSWPFxG+eL6k8UHQe230MBkDzLpVQsouFeJbwsip0mTxxJWaZXMuhyK9gaMsAQSK4YkHyI4Q==",
+      "version": "0.11.8",
+      "resolved": "https://registry.npmjs.org/@keplr-wallet/crypto/-/crypto-0.11.8.tgz",
+      "integrity": "sha512-csT7D5YxBr4ZmJ7Q1Q3+G5KRAX5/M1Y9qpeTVJTcTIo9l66atBVXgiweLQTx0KHkCma1o16l+zkPtDFnjT/FeA==",
       "dependencies": {
         "bip32": "^2.0.6",
         "bip39": "^3.0.3",
@@ -1553,14 +1553,14 @@
       }
     },
     "node_modules/@keplr-wallet/provider": {
-      "version": "0.11.3",
-      "resolved": "https://registry.npmjs.org/@keplr-wallet/provider/-/provider-0.11.3.tgz",
-      "integrity": "sha512-4KWRiJTyIBW+qOOYP2CN/IIvGMLsBgRi1D5/FT6q7EaYkIR/peJlKSR6fJukmQHyI/fmkvGH2+Td9fhZsVv5mA==",
+      "version": "0.11.8",
+      "resolved": "https://registry.npmjs.org/@keplr-wallet/provider/-/provider-0.11.8.tgz",
+      "integrity": "sha512-Xl2ovPo+V6fhIliYDk7CqCVa6qclK3oafAd70U7EWxxvhUIR502Hs2uvc+yAhe2F1X1UrJyk4EirH4vArihQzA==",
       "dependencies": {
         "@cosmjs/launchpad": "^0.24.0-alpha.25",
         "@cosmjs/proto-signing": "^0.24.0-alpha.25",
-        "@keplr-wallet/router": "0.11.3",
-        "@keplr-wallet/types": "0.11.3",
+        "@keplr-wallet/router": "0.11.8",
+        "@keplr-wallet/types": "0.11.8",
         "buffer": "^6.0.3",
         "deepmerge": "^4.2.2",
         "long": "^4.0.0",
@@ -1608,14 +1608,14 @@
       }
     },
     "node_modules/@keplr-wallet/router": {
-      "version": "0.11.3",
-      "resolved": "https://registry.npmjs.org/@keplr-wallet/router/-/router-0.11.3.tgz",
-      "integrity": "sha512-2Kh5+8ZqUY4l+Gf3mEl8q6vDeb7ino1SnCHA0bl5+ny9039zQ8AcIHjrZStX64nTPYuM/G60HRmNKhG51vMubQ=="
+      "version": "0.11.8",
+      "resolved": "https://registry.npmjs.org/@keplr-wallet/router/-/router-0.11.8.tgz",
+      "integrity": "sha512-NBHWkpc3Ed6gIfFh+SFc/+17XNFvnuFtYCc5pHLoHlqb3fCMDnvLL75BrIicVtoUS0SW6YDeNOkYZdXrgaaLpA=="
     },
     "node_modules/@keplr-wallet/types": {
-      "version": "0.11.3",
-      "resolved": "https://registry.npmjs.org/@keplr-wallet/types/-/types-0.11.3.tgz",
-      "integrity": "sha512-OA0OoimsUI22iTXgup3BAlLt+FJdGKniJqzJyQji+rqfXqreBT+Ie9c5Ng7qY81+RO/nJ5SZfa1gIns+3A0YxA==",
+      "version": "0.11.8",
+      "resolved": "https://registry.npmjs.org/@keplr-wallet/types/-/types-0.11.8.tgz",
+      "integrity": "sha512-TeQiZ5KmN8EfY06B1fvsa5eh20/o6+0+lOwKN6v2wO/zt8vdnwymEcZ0eQ2/gnrXYmdeD9YaFFPrPZHMKPSuMA==",
       "dependencies": {
         "@cosmjs/launchpad": "^0.24.0-alpha.25",
         "@cosmjs/proto-signing": "^0.24.0-alpha.25",
@@ -1674,15 +1674,15 @@
       }
     },
     "node_modules/@keplr-wallet/wc-client": {
-      "version": "0.11.3",
-      "resolved": "https://registry.npmjs.org/@keplr-wallet/wc-client/-/wc-client-0.11.3.tgz",
-      "integrity": "sha512-u7A+c5XL8+8Qa9g6Qsn6PCZBYBtOgNgIBIqpbLFpbxzBCIHH8GE+PRp1AVNsU8R5f7HHyGWHO1T14sTrdUpGEQ==",
+      "version": "0.11.8",
+      "resolved": "https://registry.npmjs.org/@keplr-wallet/wc-client/-/wc-client-0.11.8.tgz",
+      "integrity": "sha512-M69m7B6KmhCwB/fNgl4+RkBG9DmgX7q+fz70elP4AfVBaqm0uICr4zVgrEw39E5rLJqTcRvcEz28lemGpbC5wg==",
       "dependencies": {
         "@cosmjs/launchpad": "^0.24.0-alpha.25",
         "@cosmjs/proto-signing": "^0.24.0-alpha.25",
-        "@keplr-wallet/common": "0.11.3",
-        "@keplr-wallet/provider": "0.11.3",
-        "@keplr-wallet/types": "0.11.3",
+        "@keplr-wallet/common": "0.11.8",
+        "@keplr-wallet/provider": "0.11.8",
+        "@keplr-wallet/types": "0.11.8",
         "@walletconnect/types": "^1.6.4",
         "@walletconnect/utils": "^1.6.4",
         "buffer": "^6.0.3",
@@ -9125,19 +9125,19 @@
       }
     },
     "@keplr-wallet/common": {
-      "version": "0.11.3",
-      "resolved": "https://registry.npmjs.org/@keplr-wallet/common/-/common-0.11.3.tgz",
-      "integrity": "sha512-3izIyRX9nXTrc+u+24yYpl2qiLyHaweqiXI3fk2SHucWWicPqksSw5wkmuA+4Bef3/CUQPTgtcufDgPyBB+bNw==",
+      "version": "0.11.8",
+      "resolved": "https://registry.npmjs.org/@keplr-wallet/common/-/common-0.11.8.tgz",
+      "integrity": "sha512-HxOmmXT3oWb9rwZGAeZK57+NSh/qVBehV7EME8XjuvUkfV7NwCL8oZiNGfH8GZs22XoYoVXP8MCwEI7DKbLv1g==",
       "requires": {
-        "@keplr-wallet/crypto": "0.11.3",
+        "@keplr-wallet/crypto": "0.11.8",
         "buffer": "^6.0.3",
         "delay": "^4.4.0"
       }
     },
     "@keplr-wallet/crypto": {
-      "version": "0.11.3",
-      "resolved": "https://registry.npmjs.org/@keplr-wallet/crypto/-/crypto-0.11.3.tgz",
-      "integrity": "sha512-BWSEU97qBu2M7DmSWPFxG+eL6k8UHQe230MBkDzLpVQsouFeJbwsip0mTxxJWaZXMuhyK9gaMsAQSK4YkHyI4Q==",
+      "version": "0.11.8",
+      "resolved": "https://registry.npmjs.org/@keplr-wallet/crypto/-/crypto-0.11.8.tgz",
+      "integrity": "sha512-csT7D5YxBr4ZmJ7Q1Q3+G5KRAX5/M1Y9qpeTVJTcTIo9l66atBVXgiweLQTx0KHkCma1o16l+zkPtDFnjT/FeA==",
       "requires": {
         "bip32": "^2.0.6",
         "bip39": "^3.0.3",
@@ -9149,14 +9149,14 @@
       }
     },
     "@keplr-wallet/provider": {
-      "version": "0.11.3",
-      "resolved": "https://registry.npmjs.org/@keplr-wallet/provider/-/provider-0.11.3.tgz",
-      "integrity": "sha512-4KWRiJTyIBW+qOOYP2CN/IIvGMLsBgRi1D5/FT6q7EaYkIR/peJlKSR6fJukmQHyI/fmkvGH2+Td9fhZsVv5mA==",
+      "version": "0.11.8",
+      "resolved": "https://registry.npmjs.org/@keplr-wallet/provider/-/provider-0.11.8.tgz",
+      "integrity": "sha512-Xl2ovPo+V6fhIliYDk7CqCVa6qclK3oafAd70U7EWxxvhUIR502Hs2uvc+yAhe2F1X1UrJyk4EirH4vArihQzA==",
       "requires": {
         "@cosmjs/launchpad": "^0.24.0-alpha.25",
         "@cosmjs/proto-signing": "^0.24.0-alpha.25",
-        "@keplr-wallet/router": "0.11.3",
-        "@keplr-wallet/types": "0.11.3",
+        "@keplr-wallet/router": "0.11.8",
+        "@keplr-wallet/types": "0.11.8",
         "buffer": "^6.0.3",
         "deepmerge": "^4.2.2",
         "long": "^4.0.0",
@@ -9201,14 +9201,14 @@
       }
     },
     "@keplr-wallet/router": {
-      "version": "0.11.3",
-      "resolved": "https://registry.npmjs.org/@keplr-wallet/router/-/router-0.11.3.tgz",
-      "integrity": "sha512-2Kh5+8ZqUY4l+Gf3mEl8q6vDeb7ino1SnCHA0bl5+ny9039zQ8AcIHjrZStX64nTPYuM/G60HRmNKhG51vMubQ=="
+      "version": "0.11.8",
+      "resolved": "https://registry.npmjs.org/@keplr-wallet/router/-/router-0.11.8.tgz",
+      "integrity": "sha512-NBHWkpc3Ed6gIfFh+SFc/+17XNFvnuFtYCc5pHLoHlqb3fCMDnvLL75BrIicVtoUS0SW6YDeNOkYZdXrgaaLpA=="
     },
     "@keplr-wallet/types": {
-      "version": "0.11.3",
-      "resolved": "https://registry.npmjs.org/@keplr-wallet/types/-/types-0.11.3.tgz",
-      "integrity": "sha512-OA0OoimsUI22iTXgup3BAlLt+FJdGKniJqzJyQji+rqfXqreBT+Ie9c5Ng7qY81+RO/nJ5SZfa1gIns+3A0YxA==",
+      "version": "0.11.8",
+      "resolved": "https://registry.npmjs.org/@keplr-wallet/types/-/types-0.11.8.tgz",
+      "integrity": "sha512-TeQiZ5KmN8EfY06B1fvsa5eh20/o6+0+lOwKN6v2wO/zt8vdnwymEcZ0eQ2/gnrXYmdeD9YaFFPrPZHMKPSuMA==",
       "requires": {
         "@cosmjs/launchpad": "^0.24.0-alpha.25",
         "@cosmjs/proto-signing": "^0.24.0-alpha.25",
@@ -9264,15 +9264,15 @@
       }
     },
     "@keplr-wallet/wc-client": {
-      "version": "0.11.3",
-      "resolved": "https://registry.npmjs.org/@keplr-wallet/wc-client/-/wc-client-0.11.3.tgz",
-      "integrity": "sha512-u7A+c5XL8+8Qa9g6Qsn6PCZBYBtOgNgIBIqpbLFpbxzBCIHH8GE+PRp1AVNsU8R5f7HHyGWHO1T14sTrdUpGEQ==",
+      "version": "0.11.8",
+      "resolved": "https://registry.npmjs.org/@keplr-wallet/wc-client/-/wc-client-0.11.8.tgz",
+      "integrity": "sha512-M69m7B6KmhCwB/fNgl4+RkBG9DmgX7q+fz70elP4AfVBaqm0uICr4zVgrEw39E5rLJqTcRvcEz28lemGpbC5wg==",
       "requires": {
         "@cosmjs/launchpad": "^0.24.0-alpha.25",
         "@cosmjs/proto-signing": "^0.24.0-alpha.25",
-        "@keplr-wallet/common": "0.11.3",
-        "@keplr-wallet/provider": "0.11.3",
-        "@keplr-wallet/types": "0.11.3",
+        "@keplr-wallet/common": "0.11.8",
+        "@keplr-wallet/provider": "0.11.8",
+        "@keplr-wallet/types": "0.11.8",
         "@walletconnect/types": "^1.6.4",
         "@walletconnect/utils": "^1.6.4",
         "buffer": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "axios": "^0.26.0",
     "bootstrap": "^5.1.3",
     "buffer": "^6.0.3",
+    "compare-versions": "^5.0.1",
     "cosmjs-types": "^0.4.1",
     "dotenv": "^16.0.0",
     "fuzzy-search": "^3.2.1",

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -154,7 +154,7 @@ class App extends React.Component {
 
   disconnect() {
     localStorage.removeItem('connected')
-    this.state.signerProvider.disconnect()
+    this.state.signerProvider?.disconnect()
     this.setState({
       address: null,
       balance: null,

--- a/src/components/Grants.js
+++ b/src/components/Grants.js
@@ -202,7 +202,7 @@ function Grants(props) {
   const alerts = (
     <>
       {!props.grantQuerySupport && (
-        <AlertMessage variant="warning">This network doesn't fully support this feature just yet. <span role="button" className="text-decoration-underline" onClick={props.showFavouriteAddresses}>Save addresses</span> to see them here.</AlertMessage>
+        <AlertMessage variant="warning">Grants cannot be queried on this network yet. <span role="button" className="text-decoration-underline" onClick={props.showFavouriteAddresses}>Save addresses</span> first to see their grants.</AlertMessage>
       )}
       {props.grantQuerySupport && !walletAuthzSupport && (
         <AlertMessage

--- a/src/components/NetworkChecks.js
+++ b/src/components/NetworkChecks.js
@@ -50,9 +50,8 @@ function NetworkChecks(props) {
     failTitle: 'Experimental support',
     failDescription: "This network was added to REStake automatically and has not been thoroughly tested yet.",
   }
-  if(!network.authzSupport && network.operatorCount > 0){
-    testedCheck.failTitle = testedCheck.title,
-    testedCheck.failDescription = "Authz is disabled but all other features have been fully tested."
+  if(!network.authzSupport && !network.experimental){
+    testedCheck.description = "Authz is disabled but all other features have been fully tested."
   }
 
   return (
@@ -60,7 +59,7 @@ function NetworkChecks(props) {
       {([
         renderCheck({
           title: <strong>{`$${price && price.usd.toLocaleString(undefined, { maximumFractionDigits: 8, minimumFractionDigits: 2 })}`}</strong>,
-          failTitle: 'Price Unknown',
+          failTitle: 'Price unknown',
           state: price?.usd,
           identifier: 'price',
           icon: <img src={Coingecko} style={{width: '1em', height: '1em'}} className="me-2 mb-1" />,
@@ -68,7 +67,7 @@ function NetworkChecks(props) {
         }),
         renderCheck({
           title: <strong>{`${Math.round(network.estimatedApr * 100).toLocaleString()}% APR`}</strong>,
-          failTitle: 'APR Unknown',
+          failTitle: 'APR unknown',
           state: network.estimatedApr,
           identifier: 'apr',
         }),
@@ -81,8 +80,8 @@ function NetworkChecks(props) {
           identifier: 'network'
         }),
         renderCheck({
-          title: 'Authz support',
-          failTitle: 'Authz unsupported',
+          title: network.authzAminoSupport ? <strong>Full Authz support</strong> : 'Authz support',
+          failTitle: 'Authz not supported',
           failDescription: "This network doesn't support Authz just yet. You can stake and compound manually, REStake will update automatically when support is added.",
           state: network.authzSupport,
           identifier: 'authz'
@@ -94,7 +93,7 @@ function NetworkChecks(props) {
         }),
         renderCheck({
           ...testedCheck,
-          state: network.authzSupport && !network.experimental,
+          state: !network.experimental,
           identifier: 'experimental'
         }),
       ])}

--- a/src/components/NetworkSelect.js
+++ b/src/components/NetworkSelect.js
@@ -1,8 +1,5 @@
 import React, { useState, useReducer, useEffect } from 'react';
 
-import CosmosDirectory from '../utils/CosmosDirectory.mjs';
-import Network from '../utils/Network.mjs'
-
 import {
   Button,
   Modal,

--- a/src/components/Networks.js
+++ b/src/components/Networks.js
@@ -48,7 +48,7 @@ function Networks(props) {
     if (!keywords || keywords === '') return searchResults
 
     const searcher = new FuzzySearch(
-      searchResults, ['prettyName'],
+      searchResults, ['prettyName', 'keywords'],
       { sort: true }
     )
 

--- a/src/networks.json
+++ b/src/networks.json
@@ -4,8 +4,7 @@
     "gasPrice": "0.0025uosmo",
     "ownerAddress": "osmovaloper1u5v0m74mql5nzfx2yh43s2tke4mvzghr6m2n5t",
     "default": true,
-    "maxPerDay": 1,
-    "authzAminoSupport": true
+    "maxPerDay": 1
   },
   {
     "name": "juno",
@@ -102,8 +101,7 @@
     "gasPrice": "25ncheq"
   },
   {
-    "name": "umee",
-    "authzAminoSupport": true
+    "name": "umee"
   },
   {
     "name": "bitsong"

--- a/src/utils/Chain.mjs
+++ b/src/utils/Chain.mjs
@@ -4,7 +4,7 @@ import ChainAsset from "./ChainAsset.mjs";
 const Chain = (data) => {
   const assets = data.assets?.map(el => ChainAsset(el)) || []
   const baseAsset = assets[0]
-  const { cosmos_sdk_version } = data.versions
+  const { cosmos_sdk_version } = data.versions || {}
   const sdkAuthzAminoSupport = validate(cosmos_sdk_version) && compareVersions(cosmos_sdk_version, '0.46') >= 0
 
   return {

--- a/src/utils/Chain.mjs
+++ b/src/utils/Chain.mjs
@@ -1,8 +1,11 @@
+import { compareVersions, validate } from 'compare-versions';
 import ChainAsset from "./ChainAsset.mjs";
 
 const Chain = (data) => {
   const assets = data.assets?.map(el => ChainAsset(el)) || []
   const baseAsset = assets[0]
+  const { cosmos_sdk_version } = data.versions
+  const sdkAuthzAminoSupport = validate(cosmos_sdk_version) && compareVersions(cosmos_sdk_version, '0.46') >= 0
 
   return {
     ...data,
@@ -12,7 +15,7 @@ const Chain = (data) => {
     slip44: data.slip44 || 118,
     estimatedApr: data.params?.calculated_apr,
     authzSupport: data.authzSupport ?? data.params?.authz,
-    authzAminoSupport: data.authzAminoSupport ?? false,
+    authzAminoSupport: data.authzAminoSupport ?? sdkAuthzAminoSupport ?? false,
     denom: data.denom || baseAsset?.base?.denom,
     display: data.display || baseAsset?.display?.denom,
     symbol: data.symbol || baseAsset?.symbol,

--- a/src/utils/Network.mjs
+++ b/src/utils/Network.mjs
@@ -100,6 +100,7 @@ class Network {
     this.gasPricePrefer = this.data.gasPricePrefer
     this.gasModifier = this.data.gasModifier || 1.5
     this.txTimeout = this.data.txTimeout || 60_000
+    this.keywords = this.buildKeywords()
   }
 
   async connect(opts) {
@@ -196,6 +197,14 @@ class Network {
       data.features = this.data.keplrFeatures
     }
     return data
+  }
+
+  buildKeywords(){
+    return _.compact([
+      ...this.chain?.keywords || [], 
+      this.authzSupport && 'authz',
+      this.authzAminoSupport && 'full authz ledger',
+    ])
   }
 }
 

--- a/src/utils/QueryClient.mjs
+++ b/src/utils/QueryClient.mjs
@@ -206,7 +206,7 @@ const QueryClient = async (chainId, restUrls, opts) => {
     do {
       const result = await getPage(nextKey);
       pages.push(result);
-      nextKey = result.pagination.next_key;
+      nextKey = result.pagination?.next_key;
       if (pageCallback) await pageCallback(pages);
     } while (nextKey);
     return pages;


### PR DESCRIPTION
- Automatically support amino signing for v0.46 chains (requires https://github.com/eco-stake/cosmos-directory/pull/42)
- Search network keywords from chain registry, and additional 'authz' and 'ledger' keywords
- Show authz support (full or limited)
- Improve some messaging and fix a couple bugs