### PR TITLE
Disable Evmos ledger support

### DIFF
--- a/src/networks.json
+++ b/src/networks.json
@@ -79,7 +79,8 @@
     "name": "evmos",
     "txTimeout": 120000,
     "ownerAddress": "evmosvaloper1umk407eed7af6anvut6llg2zevnf0dn0feqqny",
-    "maxPerDay": 1
+    "maxPerDay": 1,
+    "ledgerSupport": false
   },
   {
     "name": "sifchain",

--- a/src/utils/Network.mjs
+++ b/src/utils/Network.mjs
@@ -85,6 +85,7 @@ class Network {
     this.coinGeckoId = this.chain.coinGeckoId
     this.estimatedApr = this.chain.estimatedApr
     this.apyEnabled = data.apyEnabled !== false && !!this.estimatedApr && this.estimatedApr > 0
+    this.ledgerSupport = this.chain.ledgerSupport ?? true
     this.authzSupport = this.chain.authzSupport
     this.authzAminoSupport = this.chain.authzAminoSupport
     this.defaultGasPrice = this.decimals && format(bignumber(multiply(0.000000025, pow(10, this.decimals))), { notation: 'fixed', precision: 4}) + this.denom

--- a/src/utils/SignerProvider.mjs
+++ b/src/utils/SignerProvider.mjs
@@ -38,9 +38,13 @@ export default class SignerProvider {
     return this.provider.enable(chainId)
   }
 
-  getKey(network){
+  async getKey(network){
     const { chainId } = network
-    return this.provider.getKey(chainId)
+    const key = await this.provider.getKey(chainId)
+    if(!network.ledgerSupport && (key.isNanoLedger || key.isHardware)){
+      throw new Error('Ledger support is coming soon')
+    }
+    return key
   }
 
   getSigner(network){


### PR DESCRIPTION
Temporarily disable ledger support for Evmos now Keplr isn't throwing an error. 

Ledger support involves signing EIP712 messages using the Ethereum app instead of amino messages with the Cosmos app, so will need a fairly deep integration. I suspect we can also support Metamask with this work.

Coming soon.. ish