### PR TITLE
Update Juno autostake batchTxs default

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ npm --version
 ```bash
 git clone https://github.com/eco-stake/restake
 cd restake
-npm install && npm run build
+npm install
 cp .env.sample .env
 ```
 

--- a/src/networks.json
+++ b/src/networks.json
@@ -9,7 +9,10 @@
   {
     "name": "juno",
     "gasPrice": "0.0025ujuno",
-    "ownerAddress": "junovaloper19ur8r2l25qhsy9xvej5zgpuc5cpn6syydmwtrt"
+    "ownerAddress": "junovaloper19ur8r2l25qhsy9xvej5zgpuc5cpn6syydmwtrt",
+    "autostake": {
+      "batchTxs": 25
+    }
   },
   {
     "name": "cosmoshub",


### PR DESCRIPTION
Juno is decreasing the max gas per block from 100m to 10m. Currently REStake defaults to sending 50 txs in a batch for Juno, which results in ~7-8m gas per gas TX. We probably want to leave some block space free, so this change decreases the default to 25 txs per batch. Potentially might need to decrease further.

This will be improved with #653 