### PR TITLE
Add Eth keplr features if slip44 is 60

### DIFF
--- a/src/utils/Network.mjs
+++ b/src/utils/Network.mjs
@@ -193,10 +193,15 @@ class Network {
       currencies: [currency],
       feeCurrencies: [{...currency, gasPriceStep: this.gasPriceStep }]
     }
-    if(this.data.keplrFeatures){
-      data.features = this.data.keplrFeatures
+    if(this.keplrFeatures()){
+      data.features = this.keplrFeatures()
     }
     return data
+  }
+
+  keplrFeatures(){
+    if(this.data.keplrFeatures) return this.data.keplrFeatures
+    if(this.slip44 === 60) return ["ibc-transfer", "ibc-go", "eth-address-gen", "eth-key-sign"]
   }
 
   buildKeywords(){


### PR DESCRIPTION
When adding a chain to Keplr from REStake, if the network is ethereum based then certain Keplr features need to be enabled. Previously this was a per-chain configuration. REStake will now identify chains with slip44 of 60 as being ethereum based and pass through the correct config to Keplr when suggesting the chain.

Resolves #658 