### PR TITLE
Autostake: Handle StakeGrant deny_list instead of allow_list

### DIFF
--- a/src/autostake/NetworkRunner.mjs
+++ b/src/autostake/NetworkRunner.mjs
@@ -163,7 +163,14 @@ export default class NetworkRunner {
         timeStamp(delegatorAddress, "Using GenericAuthorization, allowed")
         grantValidators = [validatorAddress];
       } else {
-        grantValidators = result.stakeGrant.authorization.allow_list.address
+        const { allow_list, deny_list } = result.stakeGrant.authorization
+        if(allow_list?.address){
+          grantValidators = allow_list?.address || []
+        }else if(deny_list?.address){
+          grantValidators = deny_list.address.includes(validatorAddress) ? [] : [validatorAddress]
+        }else{
+          grantValidators = []
+        }
         if (!grantValidators.includes(validatorAddress)) {
           timeStamp(delegatorAddress, "Not autostaking for this validator, skipping")
           return


### PR DESCRIPTION
Handles a StakeGrant with a deny_list instead of allow_list. This wasn't handled previously and caused autostake to error.

There is likely some work to do to support this attribute in the UI too, but that's less pressing.