### PR TITLE
Temporarily disable Stride Authz support

### DIFF
--- a/src/networks.json
+++ b/src/networks.json
@@ -234,6 +234,7 @@
   {
     "name": "stride",
     "ownerAddress": "stridevaloper1x2kta40h5rnymtjn6ys7vk2d87xu7y6zfu9j3r",
+    "authzSupport": false,
     "gasPriceStep": {
       "low": 0,
       "average": 0.025,


### PR DESCRIPTION
There is a bug with the Authz implementation introduced in v3.0.0. This will be fixed in a week or so, but this PR disables Authz support for Stride until then