### PR TITLE
Handle invalid grant deny list

### DIFF
--- a/src/autostake/NetworkRunner.mjs
+++ b/src/autostake/NetworkRunner.mjs
@@ -167,7 +167,7 @@ export default class NetworkRunner {
         if(allow_list?.address){
           grantValidators = allow_list?.address || []
         }else if(deny_list?.address){
-          grantValidators = deny_list.address.includes(validatorAddress) ? [] : [validatorAddress]
+          grantValidators = deny_list.address.includes(validatorAddress) || deny_list.address.includes('') ? [] : [validatorAddress]
         }else{
           grantValidators = []
         }

--- a/src/components/Delegations.js
+++ b/src/components/Delegations.js
@@ -221,9 +221,15 @@ class Delegations extends React.Component {
     const { claimGrant, stakeGrant } = parseGrants(grants, grantee, granter)
     let grantValidators, maxTokens;
     if (stakeGrant) {
-      grantValidators =
-        stakeGrant.authorization.allow_list?.address;
-      maxTokens = stakeGrant.authorization.max_tokens
+      const { allow_list, deny_list, max_tokens } = stakeGrant.authorization
+      if (allow_list?.address) {
+        grantValidators = allow_list?.address || []
+      } else if (deny_list?.address) {
+        grantValidators = deny_list.address.includes('') ? [] : this.props.validators.map(el => el.address).filter(address => !deny_list.address.includes(address))
+      } else {
+        grantValidators = []
+      }
+      maxTokens = max_tokens
     }
     return {
       claimGrant: claimGrant,

--- a/src/components/Grants.js
+++ b/src/components/Grants.js
@@ -96,12 +96,14 @@ function Grants(props) {
     const maxTokens = grant.authorization.max_tokens
     switch (grant.authorization['@type']) {
       case "/cosmos.staking.v1beta1.StakeAuthorization":
+        const restrictionType = grant.authorization.allow_list ? 'Validators' : 'Denied Validators'
+        const restrictionList = grant.authorization.allow_list || grant.authorization.deny_list
         return (
           <small>
             Maximum: {maxTokens ? <Coins coins={maxTokens} asset={network.baseAsset} fullPrecision={true} hideValue={true} /> : 'unlimited'}<br />
-            Validators: {grant.authorization.allow_list.address.map(address => {
+            {restrictionType}: {restrictionList.address.map(address => {
               const validator = validators[address]
-              return <div>{validator?.moniker || <Address address={address} />}</div>
+              return address ? <div key={address}>{validator?.moniker || <Address address={address} />}</div> : null
             })}
           </small>
         )

--- a/src/components/ValidatorStake.js
+++ b/src/components/ValidatorStake.js
@@ -328,10 +328,12 @@ function ValidatorStake(props) {
                               {!props.isLoading('grants') ? (
                                 grantsValid
                                   ? <span><span className="text-success">Active</span><br /><small className="text-muted">expires {expiryDate().fromNow()}</small></span>
-                                  : grantsExist
-                                    ? maxTokens && smaller(maxTokens, reward)
-                                      ? <span className="text-danger">Not enough grant remaining</span>
-                                      : <span className="text-danger">Invalid / total delegation reached</span>
+                                  : grantsExist 
+                                    ? !validatorGrants.validators.includes(validator.address)
+                                      ? <span className="text-danger">Grant invalid</span>
+                                      : maxTokens && smaller(maxTokens, reward)
+                                        ? <span className="text-danger">Not enough grant remaining</span>
+                                        : <span className="text-danger">Invalid / total delegation reached</span>
                                     : network.authzSupport ? <em>Inactive</em> : <em>Authz not supported</em>
                               ) : (
                                 <Spinner animation="border" role="status" className="spinner-border-sm">


### PR DESCRIPTION
Blockscape found that grants with a deny_list containing an empty string don't allow MsgDelegate. Attempting to send a MsgDelegate via MsgExec fails with the error: 

`rpc error: code = Unknown desc = failed to execute message; message index: 0: cannot delegate/undelegate to <valoperaddress> validator: unauthorized`

This PR identifies grants with this deny_list and treats them as invalid grants in the UI and when autostaking. 