### PR TITLE
Re-enable Stride Authz

### DIFF
--- a/src/networks.json
+++ b/src/networks.json
@@ -234,7 +234,6 @@
   {
     "name": "stride",
     "ownerAddress": "stridevaloper1x2kta40h5rnymtjn6ys7vk2d87xu7y6zfu9j3r",
-    "authzSupport": false,
     "gasPriceStep": {
       "low": 0,
       "average": 0.025,


### PR DESCRIPTION
Draft until the following URL returns a successful response: https://rest.cosmos.directory/stride/cosmos/authz/v1beta1/grants/granter/stride19d3c8zvvg8eyvfehz28retuha6lqfq4qdhuzcv?pagination.limit=100