### PR TITLE
chore: update Desmos Authz support

### DIFF
--- a/src/networks.json
+++ b/src/networks.json
@@ -72,7 +72,9 @@
   },
   {
     "name": "desmos",
-    "gasPrice": "0.001udsm"
+    "gasPrice": "0.001udsm",
+    "authzSupport": true,
+    "authzAminoSupport": true
   },
   {
     "name": "cryptoorgchain",


### PR DESCRIPTION
With our latest upgrade, we have implemented the Authz support for Ledger devices inside our mainnet. This PR updates the `networks.json` file to reflect these changes.