### PR TITLE
Configurable networks.json Override Filepath

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ npm run dryrun osmosis
 
 You will likely want to customise your networks config, e.g. to set your own node URLs to ensure your autocompounding script completes successfully.
 
-Create a `src/networks.local.json` file and specify the networks you want to override. The below is just an example, **you should only override a config if you need to**.
+Create a `src/networks.local.json` file and specify the networks you want to override. Alternatively, set the `NETWORKS_OVERRIDE_PATH` environment variable containing the filepath. The below is just an example, **you should only override a config if you need to**.
 
 ```json
 {

--- a/scripts/autostake.mjs
+++ b/scripts/autostake.mjs
@@ -2,6 +2,7 @@ import 'dotenv/config'
 import Autostake from "../src/autostake/index.mjs";
 
 const mnemonic = process.env.MNEMONIC
+const networksOverridePath = process.env.NETWORKS_OVERRIDE_PATH || 'src/networks.local.json'
 const autostake = new Autostake(mnemonic);
 const networkNames = process.argv.slice(2, process.argv.length)
-autostake.run(networkNames)
+autostake.run(networkNames, networksOverridePath)

--- a/src/autostake/index.mjs
+++ b/src/autostake/index.mjs
@@ -23,8 +23,8 @@ export default function Autostake(mnemonic, opts) {
     process.exit()
   }
 
-  async function run(networkNames) {
-    const networks = getNetworksData()
+  async function run(networkNames, networksOverridePath) {
+    const networks = getNetworksData(networksOverridePath)
     for (const name of networkNames) {
       if (name && !networks.map(el => el.name).includes(name)) return timeStamp('Invalid network name:', name)
     }
@@ -189,11 +189,11 @@ export default function Autostake(mnemonic, opts) {
     return { signer, slip44 }
   }
 
-  function getNetworksData() {
+  function getNetworksData(networksOverridePath) {
     const networksData = fs.readFileSync('src/networks.json');
     const networks = JSON.parse(networksData);
     try {
-      const overridesData = fs.readFileSync('src/networks.local.json');
+      const overridesData = fs.readFileSync(networksOverridePath);
       const overrides = overridesData && JSON.parse(overridesData) || {}
       return overrideNetworks(networks, overrides)
     } catch (error) {


### PR DESCRIPTION
Make `networks.json` override filepath configurable via environment variable `NETWORKS_OVERRIDE_PATH` instead of exclusively defaulting to `src/networks.local.json`. 