### PR TITLE
Evmos update fixes

### DIFF
--- a/src/networks.json
+++ b/src/networks.json
@@ -86,7 +86,7 @@
     "txTimeout": 120000,
     "ownerAddress": "evmosvaloper1umk407eed7af6anvut6llg2zevnf0dn0feqqny",
     "maxPerDay": 1,
-    "ledgerSupport": false
+    "authzAminoSupport": false
   },
   {
     "name": "sifchain",

--- a/src/utils/Vote.mjs
+++ b/src/utils/Vote.mjs
@@ -1,3 +1,5 @@
+import { equal } from 'mathjs'
+
 export const VOTE_CHOICES = {
   'VOTE_OPTION_YES': 'Yes',
   'VOTE_OPTION_NO': 'No',
@@ -14,11 +16,19 @@ export const VOTE_VALUES = {
 
 const Vote = (data) => {
 
-  const optionHuman = VOTE_CHOICES[data.option]
-  const optionValue = VOTE_VALUES[data.option]
+  let option = data.option
+  let optionHuman = VOTE_CHOICES[data.option]
+  let optionValue = VOTE_VALUES[data.option]
+
+  if(!optionValue && data.options?.length){
+    option = data.options.find(el => equal(el.weight, 1))?.option
+    optionHuman = option ? VOTE_CHOICES[option] : 'Multiple'
+    optionValue = option ? VOTE_VALUES[option] : null // doesn't support multiple right now
+  }
 
   return {
     ...data,
+    option,
     optionHuman,
     optionValue
   }


### PR DESCRIPTION
Disables Amino Authz support as this requires Ethereum formatted messages, coming soon.

Supports governance votes when primary option is 'UNSPECIFIED' but actual vote is in the `options` weighted array. Very basic support for multiple vote options, although you can't submit a vote with multiple weights just yet. 