### PR TITLE
Update Axios dep to v1.3.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@testing-library/user-event": "^13.5.0",
         "@tharsis/address-converter": "^0.1.8",
         "@walletconnect/client": "^1.8.0",
-        "axios": "^0.26.0",
+        "axios": "^1.3.4",
         "axios-retry": "^3.3.1",
         "bootstrap": "^5.1.3",
         "buffer": "^6.0.3",
@@ -3971,11 +3971,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "0.26.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.4.tgz",
+      "integrity": "sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==",
       "dependencies": {
-        "follow-redirects": "^1.14.8"
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/axios-retry": {
@@ -5401,9 +5403,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.14.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
-      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
       "funding": [
         {
           "type": "individual",
@@ -7000,6 +7002,11 @@
       "version": "13.13.52",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.52.tgz",
       "integrity": "sha512-s3nugnZumCC//n4moGGe6tkNMyYEdaDBitVjwPxXmR5lnMG5dHePinH2EdxkG3Rh1ghFHHixAG4NJhpJW1rthQ=="
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/public-encrypt": {
       "version": "4.0.3",
@@ -10943,11 +10950,13 @@
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
     },
     "axios": {
-      "version": "0.26.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.4.tgz",
+      "integrity": "sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==",
       "requires": {
-        "follow-redirects": "^1.14.8"
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "axios-retry": {
@@ -12064,9 +12073,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.14.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
-      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w=="
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
     },
     "form-data": {
       "version": "4.0.0",
@@ -13225,6 +13234,11 @@
           "integrity": "sha512-s3nugnZumCC//n4moGGe6tkNMyYEdaDBitVjwPxXmR5lnMG5dHePinH2EdxkG3Rh1ghFHHixAG4NJhpJW1rthQ=="
         }
       }
+    },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "public-encrypt": {
       "version": "4.0.3",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@testing-library/user-event": "^13.5.0",
     "@tharsis/address-converter": "^0.1.8",
     "@walletconnect/client": "^1.8.0",
-    "axios": "^0.26.0",
+    "axios": "^1.3.4",
     "axios-retry": "^3.3.1",
     "bootstrap": "^5.1.3",
     "buffer": "^6.0.3",


### PR DESCRIPTION
NPMAudit is failing with the following vulnerabilities:

```
==== NPMAudit v6.14.8: FAILED in 2.68s

 ~~ Scanner Logs:

  ┌─────────┬──────────────────┬──────────────────┬──────┬──────────────────────────────────────────
  ─┬──────┬─────┐
  │ ID      │ Module           │ Title            │ Sev. │ URL
   │ Prod │ Ex. │
  ├─────────┼──────────────────┼──────────────────┼──────┼──────────────────────────────────────────
  ─┼──────┼─────┤
  │ 1088828 │ decode-uri-comp~ │ decode-uri-comp~ │ low  │ github.com/advisories/GHSA-w573-4hg7-7wgq
   │ yes  │ no  │
  │ 1089547 │ axios            │ axios Inefficie~ │ high │ github.com/advisories/GHSA-cph5-m8f7-6c5x
   │ yes  │ no  │
  │ 1091148 │ json5            │ Prototype Pollu~ │ high │ github.com/advisories/GHSA-9c47-m6qq-7p4h
   │ yes  │ no  │
  └─────────┴──────────────────┴──────────────────┴──────┴──────────────────────────────────────────
  ─┴──────┴─────┘
```

This PR updates the axios dependency to `v1.3.4`. 

## Testing

`npm start` runs and successfully renders the UI.
Unclear