### PR TITLE
Update Umee gas price

### DIFF
--- a/src/networks.json
+++ b/src/networks.json
@@ -111,7 +111,8 @@
     "gasPrice": "25ncheq"
   },
   {
-    "name": "umee"
+    "name": "umee",
+    "gasPrice": "0.05uumee"
   },
   {
     "name": "bitsong"


### PR DESCRIPTION
Matches Chain Registry 'low' gas price for REStake operators.

This will become dynamic in the future. 

Resolves #715 