### PR TITLE
Handle unknown networks

### DIFF
--- a/src/autostake/NetworkRunner.mjs
+++ b/src/autostake/NetworkRunner.mjs
@@ -135,8 +135,10 @@ export default class NetworkRunner {
       }
     })
     let grantedAddresses = await mapSync(grantCalls, this.opts.batchQueries, (batch, index) => {
-      timeStamp('...batch', index + 1)
-      return this.throttleQuery()
+      if(!allGrants){
+        timeStamp('...batch', index + 1)
+        return this.throttleQuery()
+      }
     })
     return _.compact(grantedAddresses.flat())
   }
@@ -314,7 +316,7 @@ export default class NetworkRunner {
   }
 
   async throttleQuery(){
-    if(!this.opts.queryThrottle) return 
+    if(!this.opts.queryThrottle) return
 
     await new Promise(r => setTimeout(r, this.opts.queryThrottle));
   }


### PR DESCRIPTION
Currently running the autostake script will fail if the network is not included in networks.json or networks.local.json. Networks only present in Chain Registry had to be added to networks.local.json with empty config before the script would recognise them.

This PR instead assumes the network will be found in Chain Registry if the script is run with a network name, and will only fail if the network is not present in Chain Registry. E.g. `npm run autostake nois` will now lookup `nois` in the Registry and work as expected.

Running the script without a network (`npm run autostake`) will continue to run the script for all networks in networks.json AND networks.local.json. It will not run for every chain in Registry, as this will take a long time. 

Future updates will change this `npm run autostake` command without arguments to only run for chains in networks.local.json, since this is more adaptable, but for now it remains as-is.