### PR TITLE
Add automated health checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,24 @@ Add your Check UUID to the relevant network in your `networks.local.json` config
 }
 ```
 
+If you wish for your health checks to be created automatically, you can provide an [API key](https://healthchecks.io/docs/api/) to manage it for you. 
+The default behavior is for the check to be named after the network, but this can be overridden with the `name` property. 
+
+**Note that the `uuid` is not necessary when using an `apiKey` to create checks automatically.**
+
+```JSON
+{
+  "cheqd": {
+    "healthCheck": {
+      "apiKey": "12_CanM1Q3T72uGH4kc32G14BdA4Emc4y",
+      "name": "cheqd every 12 hours", // optional, defaults to the network name
+      "timeout": 43200, // optional, expected seconds between each run
+      "gracePeriod": 86400, // optional, grace period seconds before it notifies
+    }
+  }
+}
+```
+
 ### Submitting your operator
 
 #### Setup your REStake operator

--- a/src/autostake/Health.mjs
+++ b/src/autostake/Health.mjs
@@ -7,12 +7,19 @@ class Health {
     const { address, uuid, name, apiKey } = config || {}
     const { dryRun, networkName } = opts || {}
     this.address = address || 'https://hc-ping.com'
-    this.uuid = uuid
     this.name = name || networkName
     this.apiKey = apiKey
     this.dryRun = dryRun
+    this.uuid = uuid
     this.logs = []
-    this.pingUrl = this.getOrCreateHealthCheck();
+    this.getOrCreateHealthCheck()
+
+    if (address) {
+      // This is necessary as the default provider - hc-ping.com - has a built in ping mechanism
+      // whereas providing self-hosted addresses do NOT. 
+      // https://healthchecks.selfhosted.com/ping/{uuid} rather than https://hc-ping.com/{uuid}
+      this.address = this.address + "/ping"
+    }
   }
 
   started(...args) {
@@ -55,10 +62,10 @@ class Health {
 
     try {
       await axios.post([this.address, 'api/v2/checks/'].join('/'), data, config).then((res) => {
-        this.uuid = res.data.ping_url.split('/')[4];
+        this.uuid = res.data.ping_url.split('/')[4]
       });
     } catch (error) {
-      timeStamp("Health Check creation failed: " + error);
+      timeStamp("Health Check creation failed: " + error)
     }
   }
 

--- a/src/autostake/Health.mjs
+++ b/src/autostake/Health.mjs
@@ -4,11 +4,13 @@ import { timeStamp } from '../utils/Helpers.mjs'
 
 class Health {
   constructor(config, opts) {
-    const { address, uuid, name, apiKey } = config || {}
+    const { address, uuid, name, apiKey, timeout, gracePeriod } = config || {}
     const { dryRun, networkName } = opts || {}
     this.address = address || 'https://hc-ping.com'
-    this.uuid = uuid
     this.name = name || networkName
+    this.gracePeriod = gracePeriod || 86400   // default 24 hours
+    this.timeout = timeout || 86400           // default 24 hours
+    this.uuid = uuid
     this.apiKey = apiKey
     this.dryRun = dryRun
     this.logs = []
@@ -57,7 +59,7 @@ class Health {
     }
 
     let data = {
-      "name": this.name, "channels": "*", "timeout": 43200, "grace": 86400, "unique": ["name"]
+      "name": this.name, "channels": "*", "timeout": this.timeout, "grace": this.gracePeriod, "unique": ["name"]
     }
 
     try {

--- a/src/autostake/Health.mjs
+++ b/src/autostake/Health.mjs
@@ -7,10 +7,10 @@ class Health {
     const { address, uuid, name, apiKey } = config || {}
     const { dryRun, networkName } = opts || {}
     this.address = address || 'https://hc-ping.com'
+    this.uuid = uuid
     this.name = name || networkName
     this.apiKey = apiKey
     this.dryRun = dryRun
-    this.uuid = uuid
     this.logs = []
     this.getOrCreateHealthCheck()
 

--- a/src/autostake/Health.mjs
+++ b/src/autostake/Health.mjs
@@ -4,51 +4,75 @@ import { timeStamp } from '../utils/Helpers.mjs'
 
 class Health {
   constructor(config, opts) {
-    const { address, uuid } = config || {}
-    const { dryRun } = opts || {}
+    const { address, uuid, name, api_key } = config || {}
+    const { dryRun, networkName } = opts || {}
+    console.log(networkName);
     this.address = address || 'https://hc-ping.com'
     this.uuid = uuid
+    this.name = name || networkName
+    this.api_key = api_key
     this.dryRun = dryRun
     this.logs = []
+    this.pingUrl = this.getOrCreateHealthCheck();
   }
 
-  started(...args){
+  getOrCreateHealthCheck(...args) {
+    if (!this.api_key) return;
+
+    let config = {
+      headers: {
+        "X-Api-Key": this.api_key,
+      }
+    }
+
+    let data = {
+      "name": this.name, "channels": "*", "timeout": 43200, "grace": 86400, "unique": ["name"]
+    }
+
+    try {
+      var response = await axios.post([this.address, 'api/v2/checks/'].join('/'), data, config).then((res) => res.data.pingUrl);
+    } catch (error) {
+      timeStamp("Health Check creation failed: " + error);
+    }
+  }
+
+  started(...args) {
     timeStamp(...args)
-    if(this.uuid) timeStamp('Starting health', [this.address, this.uuid].join('/'))
+    if (this.uuid) timeStamp('Starting health', [this.address, this.uuid].join('/'))
     return this.ping('start', [args.join(' ')])
   }
 
-  success(...args){
+  success(...args) {
     timeStamp(...args)
     return this.ping(undefined, [...this.logs, args.join(' ')])
   }
 
-  failed(...args){
+  failed(...args) {
     timeStamp(...args)
     return this.ping('fail', [...this.logs, args.join(' ')])
   }
 
-  log(...args){
+  log(...args) {
     timeStamp(...args)
     this.logs = [...this.logs, args.join(' ')]
   }
 
-  addLogs(logs){
+  addLogs(logs) {
     this.logs = this.logs.concat(logs)
   }
 
-  async sendLog(){
+  async sendLog() {
     await this.ping('log', this.logs)
     this.logs = []
   }
 
-  async ping(action, logs){
-    if(!this.uuid) return
-    if(this.dryRun) return timeStamp('DRYRUN: Skipping health check ping')
+  async ping(action, logs) {
+    if (!this.uuid) return
+    if (this.dryRun) return timeStamp('DRYRUN: Skipping health check ping')
 
     return axios.request({
       method: 'POST',
-      url: _.compact([this.address, this.uuid, action]).join('/'), 
+      url: _.compact([this.address, this.uuid, action]).join('/'),
       data: logs.join("\n")
     }).catch(error => {
       timeStamp('Health ping failed', error.message)

--- a/src/autostake/index.mjs
+++ b/src/autostake/index.mjs
@@ -36,8 +36,8 @@ export default function Autostake(mnemonic, opts) {
       return async () => {
         if (networkNames && networkNames.length && !networkNames.includes(data.name)) return
         if (data.enabled === false) return
-
-        const health = new Health(data.healthCheck, { dryRun: opts.dryRun })
+        console.log(data);
+        const health = new Health(data.healthCheck, { dryRun: opts.dryRun, networkName: data.name })
         health.started('⚛')
         const results = await runWithRetry(data, health)
         const { success, skipped } = results[results.length - 1] || {}

--- a/src/autostake/index.mjs
+++ b/src/autostake/index.mjs
@@ -36,7 +36,7 @@ export default function Autostake(mnemonic, opts) {
       return async () => {
         if (networkNames && networkNames.length && !networkNames.includes(data.name)) return
         if (data.enabled === false) return
-        console.log(data);
+
         const health = new Health(data.healthCheck, { dryRun: opts.dryRun, networkName: data.name })
         health.started('⚛')
         const results = await runWithRetry(data, health)

--- a/src/networks.local.json.sample
+++ b/src/networks.local.json.sample
@@ -1,0 +1,8 @@
+{
+  "akash": {
+    "prettyName": "Akash",
+    "restUrl": [
+      "https://rest.validator.com/osmosis"
+    ]
+  }
+}

--- a/src/networks.local.json.sample
+++ b/src/networks.local.json.sample
@@ -1,8 +1,0 @@
-{
-  "akash": {
-    "prettyName": "Akash",
-    "restUrl": [
-      "https://rest.validator.com/osmosis"
-    ]
-  }
-}


### PR DESCRIPTION
There are really 3 parts to this PR:
1. I ran an auto-formatter, so it copied the formatting against the rest of the repo 
2. Fixed self-hosted healthchecks, as the normal healthchecks.io uses a different ping path system
3. Added functionality for auto-created healthchecks. This only kicks in if the `apiKey` property is added, and is created based off of the `name` property (which defaults to `networkName`)