### PR TITLE
Adding Source Protocol to networks.json

### DIFF
--- a/src/networks.json
+++ b/src/networks.json
@@ -228,7 +228,12 @@
   },
   {
     "name": "echelon",
-    "keplrFeatures": ["ibc-transfer", "ibc-go", "eth-address-gen", "eth-key-sign"]
+    "keplrFeatures": [
+      "ibc-transfer",
+      "ibc-go",
+      "eth-address-gen",
+      "eth-key-sign"
+    ]
   },
   {
     "name": "kichaintestnet",
@@ -320,9 +325,6 @@
   },
   {
     "name": "source",
-    "gasPrice": "0.025usource",
-    "autostake": {
-      "gasModifier": 1.4
-    }
+    "gasPrice": "0.05usource"
   }
 ]

--- a/src/networks.json
+++ b/src/networks.json
@@ -320,9 +320,6 @@
   },
   {
     "name": "source",
-    "gasPrice": "0.05usource",
-    "autostake": {
-      "retries": 10
-    }   
+    "gasPrice": "0.05usource"
   }
 ]

--- a/src/networks.json
+++ b/src/networks.json
@@ -228,7 +228,12 @@
   },
   {
     "name": "echelon",
-    "keplrFeatures": ["ibc-transfer", "ibc-go", "eth-address-gen", "eth-key-sign"]
+    "keplrFeatures": [
+      "ibc-transfer",
+      "ibc-go",
+      "eth-address-gen",
+      "eth-key-sign"
+    ]
   },
   {
     "name": "kichaintestnet",
@@ -317,5 +322,12 @@
     "name": "coreum",
     "ownerAddress": "corevaloper1py9v5f7e4aaka55lwtthk30scxhnqfa6agwxt8",
     "gasPrice": "0.0625ucore"
+  },
+  {
+    "name": "source",
+    "gasPrice": "0.025usource",
+    "autostake": {
+      "gasModifier": 1.4
+    }
   }
 ]

--- a/src/networks.json
+++ b/src/networks.json
@@ -320,6 +320,9 @@
   },
   {
     "name": "source",
-    "gasPrice": "0.05usource"
+    "gasPrice": "0.05usource",
+    "autostake": {
+      "retries": 10
+    }   
   }
 ]

--- a/src/networks.json
+++ b/src/networks.json
@@ -228,12 +228,7 @@
   },
   {
     "name": "echelon",
-    "keplrFeatures": [
-      "ibc-transfer",
-      "ibc-go",
-      "eth-address-gen",
-      "eth-key-sign"
-    ]
+    "keplrFeatures": ["ibc-transfer", "ibc-go", "eth-address-gen", "eth-key-sign"]
   },
   {
     "name": "kichaintestnet",


### PR DESCRIPTION
Hi!

Here's a request to add the Source protocol to the networks.json file. I made sure to only add the necessary values in order for autostaking _(or transactions in general)_ to work; which are the `gasPrice` and `gasModifier`.

Have a great day!

PS: I didn't see any other network with the `gasModifier` value set, but I presume it should work since some have the `autostake` object included.

---

https://sourceprotocol.io
https://restake.app/source