### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # dev env
-FROM node:18-slim
+FROM node:18-buster
 
 RUN apt-get update && apt-get install -y python3 make g++
 


### PR DESCRIPTION
slim uses debian bookworm and is not supported anymore. This causes "gpg" errors.