### PR TITLE
docs: remove Ledger limitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ A script is also provided which allows a validator to automatically search their
 
 ## Limitations
 
-- As of writing, Ledger is unable to send the necessary transactions to enable Authz. This is purely due to the way transactions are sent to a Ledger device and a workaround should be possible soon.
 - Authz is also not fully supported yet. Many chains are yet to update. The REStake UI will fall back to being a manual staking app with useful manual compounding features.
 - Currently REStake needs the browser extension version of Keplr, but WalletConnect and Keplr iOS functionality will be added ASAP.
 - REStake requires Nodejs version 18.x or later, it will not work with earlier versions.
@@ -165,7 +164,6 @@ npm run dryrun osmosis
 
 **You should expect to see a warning that you are 'not an operator' until your REStake operator information is submitted in [Submitting your operator](#submitting-your-operator)**
 
-
 ### Customise REStake and use your own node
 
 You will likely want to customise your networks config, e.g. to set your own node URLs to ensure your autocompounding script completes successfully.
@@ -222,7 +220,7 @@ Don't forget to [update often](#updating-your-local-version)!
 
 #### Using `crontab`
 
-Note: A helpful calculator for determining your REStake timer for `crontab` can be found here: https://crontab.guru/.
+Note: A helpful calculator for determining your REStake timer for `crontab` can be found here: <https://crontab.guru/>.
 
 Updated versions utilize `docker compose` instead of `docker-compose`. If you run into issues, try substituting `docker compose`.
 
@@ -282,7 +280,7 @@ For NPM installs, remove `Requires` and `After` directives, and change `ExecStar
 
 The timer file defines the rules for running the restake service every day. All rules are described in the [systemd documentation](https://www.freedesktop.org/software/systemd/man/systemd.timer.html).
 
-Note: Helpful calculator for determining restake times for `OnCalendar` can also be found at https://crontab.guru/.
+Note: Helpful calculator for determining restake times for `OnCalendar` can also be found at <https://crontab.guru/>.
 
 ```bash
 sudo vim /etc/systemd/system/restake.timer
@@ -347,8 +345,8 @@ Add your Check UUID to the relevant network in your `networks.local.json` config
 }
 ```
 
-If you wish for your health checks to be created automatically, you can provide an [API key](https://healthchecks.io/docs/api/) to manage it for you. 
-The default behavior is for the check to be named after the network, but this can be overridden with the `name` property. 
+If you wish for your health checks to be created automatically, you can provide an [API key](https://healthchecks.io/docs/api/) to manage it for you.
+The default behavior is for the check to be named after the network, but this can be overridden with the `name` property.
 
 **Note that the `uuid` is not necessary when using an `apiKey` to create checks automatically.**
 
@@ -388,7 +386,7 @@ You now need to update the [Validator Registry](https://github.com/eco-stake/val
 
 `address` is your validator's address, and `restake.address` is the address from your new hot wallet you generated earlier.
 
-`restake.run_time` is the time *in UTC* that you intend to run your bot, and there are a few options. Pass a single time, e.g. `09:00` to specify a single run at 9am UTC. Use an array for multiple specified times, e.g. `["09:00", "21:00"]`. Use an interval string for multiple times per hour/day, e.g. `"every 15 minutes"`.
+`restake.run_time` is the time _in UTC_ that you intend to run your bot, and there are a few options. Pass a single time, e.g. `09:00` to specify a single run at 9am UTC. Use an array for multiple specified times, e.g. `["09:00", "21:00"]`. Use an interval string for multiple times per hour/day, e.g. `"every 15 minutes"`.
 
 `restake.minimum_reward` is the minimum reward to trigger autostaking, otherwise the address is skipped. This could be set higher for more frequent restaking. Note this is in the base denomination, e.g. `uosmo`.
 

--- a/README_TURKISH.md
+++ b/README_TURKISH.md
@@ -20,8 +20,6 @@ Doğrulayıcının delegelerini otomatik olarak aramasını sağlayan bir komut 
 
 ## Kısıtlamalar
 
-Yazılı olarak, Ledger, Authz (Yetkilendirmeyi) etkinleştirmek için gerekli işlemleri gönderemiyor. Bu tamamen işlemlerin bir Ledger cihazına gönderilme şeklinden kaynaklanmaktadır ve yakında bir geçici çözüm mümkün olabilecektir.
-
 Authz da henüz tam olarak desteklenmemektedir. Birçok zincir henüz güncellenmedi. REStake UI, kullanışlı manuel birleştirme özelliklerine sahip bir manuel stake uygulaması olmaya geri dönecek.
 
 Şu anda REStake, Keplr'ın tarayıcı uzantısı sürümüne ihtiyaç duyuyor, ancak WalletConnect ve Keplr iOS işlevselliği en kısa sürede eklenecek.
@@ -110,6 +108,7 @@ cd restake
 npm install && npm run build
 cp .env.sample .env
 ```
+
 **Yeni .env dosyanıza anımsatıcı kelimelerinizi yazın.**
 
 #### Yerel versiyonunuzu güncelleme
@@ -162,7 +161,6 @@ npm run dryrun osmosis
 ```
 
 **REStake operatör bilgilerinizi [Operatörünüzü kaydetme](#operat%C3%B6r%C3%BCn%C3%BCz%C3%BC-kaydetme) bölümünde gösterileceği gibi [Validator Kayıt Defteri](https://github.com/eco-stake/validator-registry)'ne kaydınızı yapana kadar 'operatör olmadığınıza dair bir uyarı görebilirsiniz.**
-
 
 ### REStake'i özelleştirin ve node'unuzu kullanın
 
@@ -220,7 +218,7 @@ Her iki durumda da, sistem zamanınızın doğru olduğundan emin olun ve komut 
 
 #### `crontab` Kullanma
 
-NOT: REStake zamanlayıcınızı `crontab`'a göre belirlemek için faydalı bir hesap makinesini buradan ulaşabilirsiniz: https://crontab.guru/.
+NOT: REStake zamanlayıcınızı `crontab`'a göre belirlemek için faydalı bir hesap makinesini buradan ulaşabilirsiniz: <https://crontab.guru/>.
 
 Güncellenmiş sürümler, `docker-compose` yerine `docker compose` kullanır. Sorunlarla karşılaşırsanız, `docker compose` yerine bunu kullanmayı deneyin.
 
@@ -261,9 +259,10 @@ ExecStart=/usr/bin/docker-compose run --rm app npm run autostake
 [Install]
 WantedBy=multi-user.target
 ```
-NPM kurulumu için `Requires` ve `After` direktiflerini kaldırın ve` `ExecStart`'ı` `ExecStart=/usr/bin/npm run autostake` olarak değiştirin.
 
-🔴 **Not: Sorun yaşarsanız `WorkingDirectory=/path/to/restake` bölümünü `WorkingDirectory=/root/restake` olarak değiştiriniz. Eğer yine sorun yaşarsanız `chmod 777 /root/restake` komutu ile dosyaya okuma, yazma ve çalıştırma izni veriniz. Daha sonra `systemctl daemon-reload` yaptıktan sonra sistemi yeniden başlatınız. **
+NPM kurulumu için `Requires` ve `After` direktiflerini kaldırın ve``ExecStart`'ı` `ExecStart=/usr/bin/npm run autostake` olarak değiştirin.
+
+🔴 **Not: Sorun yaşarsanız `WorkingDirectory=/path/to/restake` bölümünü `WorkingDirectory=/root/restake` olarak değiştiriniz. Eğer yine sorun yaşarsanız `chmod 777 /root/restake` komutu ile dosyaya okuma, yazma ve çalıştırma izni veriniz. Daha sonra `systemctl daemon-reload` yaptıktan sonra sistemi yeniden başlatınız.**
 
 🔴 **Eğer `Failed to restake service with docker compose` gibi bir hata alırsanız yine `chmod 777 /usr/bin/docker-compose` komutu ile dosyaya okuma, yazma ve çalıştırma izni veriniz.**
 
@@ -271,9 +270,9 @@ NPM kurulumu için `Requires` ve `After` direktiflerini kaldırın ve` `ExecStar
 
 ##### systemd timer dosyası oluşturma
 
-Zamanlayıcı dosyası, yeniden düzenleme hizmetini her gün çalıştırma kurallarını tanımlar. Tüm kurallar [systemd dokümanlarında] (https://www.freedesktop.org/software/systemd/man/systemd.timer.html) açıklanmaktadır.
+Zamanlayıcı dosyası, yeniden düzenleme hizmetini her gün çalıştırma kurallarını tanımlar. Tüm kurallar [systemd dokümanlarında] (<https://www.freedesktop.org/software/systemd/man/systemd.timer.html>) açıklanmaktadır.
 
-Not: `OnCalendar` için restake sürelerini belirlemek için yararlı hesap makinesi https://crontab.guru/ adresinde bulunabilir.
+Not: `OnCalendar` için restake sürelerini belirlemek için yararlı hesap makinesi <https://crontab.guru/> adresinde bulunabilir.
 
 ```bash
 sudo vim /etc/systemd/system/restake.timer
@@ -318,7 +317,7 @@ TriggeredBy: <font color="#8AE234"><b>●</b></font> restake.timer
 
 ### İzleme
 
-Her ağ için komut dosyası durumunu bildirmek için REStake oto-stake betiği [healthchecks.io] (https://healthchecks.io/) ile entegre olabilir. [HealthChecks.io] (https://healthchecks.io/) daha sonra, herhangi bir arızayı bildiğinizden emin olmak için e -posta, Discord ve Slack gibi birçok bildirim platformuyla entegre edilebilir.
+Her ağ için komut dosyası durumunu bildirmek için REStake oto-stake betiği [healthchecks.io] (<https://healthchecks.io/>) ile entegre olabilir. [HealthChecks.io] (<https://healthchecks.io/>) daha sonra, herhangi bir arızayı bildiğinizden emin olmak için e -posta, Discord ve Slack gibi birçok bildirim platformuyla entegre edilebilir.
 
 Yapılandırıldıktan sonra, komut dosyası başladığında, başarılı ya da başarısız olduğunda REStake [healthchecks.io](https://healthchecks.io/)'a ping atacaktır. Kontrol günlüğü ilgili hata bilgilerini içerecektir ve yapılandırılması basittir.
 
@@ -341,7 +340,6 @@ Kontrol UUID numaranızı aşağıdaki gibi `networks.local.json` yapılandırma
 #### REStake Operatörünüzü Kurma
 
 Artık operatör bilgilerinizi oto-sake'i aktif etmek istediğiniz ağları eklemek için [Validator Kayıt Defteri](https://github.com/eco-stake/validator-registry)'ni güncellemeniz gerekiyor. Örnekler için README ve mevcut doğrulayıcıları kontrol edebilirsiniz, ancak bir ağ için yapılandırma şuna benziyor:
-
 
 ```json
 {
@@ -370,15 +368,15 @@ REStake yapmak istediğiniz tüm ağlar için bu yapılandırmayı tekrarlayın.
 
 #### Operatörünüzü Validator Kayıt Defterine kaydetme
 
-Artık [Validator Kayıt Defteri] (https://github.com/eco-stake/validator-registry) güncellemenizi mümkün olan en kısa sürede merge edilmek üzere pull request isteğinde bulunabilirsiniz. REStake, değişikliklerin birleştirilmesinden sonraki 15 dakika içinde otomatik olarak güncellenir.
+Artık [Validator Kayıt Defteri] (<https://github.com/eco-stake/validator-registry>) güncellemenizi mümkün olan en kısa sürede merge edilmek üzere pull request isteğinde bulunabilirsiniz. REStake, değişikliklerin birleştirilmesinden sonraki 15 dakika içinde otomatik olarak güncellenir.
 
 ## Katkıda Bulunma
 
 ### Bir Ağ Ekleme/Güncelleme
 
-Ağ bilgileri [Zincir Kayıt Defteri] (https://github.com/cosmos/chain-registry) [registry.cosmos.directory] (https://registry.cosmos.directory) API üzerinden alınır. Yeterli temel bilgilerin sağlandığı varsayılarak, REStake'e ana daldaki zincirler otomatik olarak eklenir.
+Ağ bilgileri [Zincir Kayıt Defteri] (<https://github.com/cosmos/chain-registry>) [registry.cosmos.directory] (<https://registry.cosmos.directory>) API üzerinden alınır. Yeterli temel bilgilerin sağlandığı varsayılarak, REStake'e ana daldaki zincirler otomatik olarak eklenir.
 
-'networks.json' dosyası, REStake'de 'desteklendiği' gibi hangi zincirlerin göründüğünü tanımlar; zincir adı Zincir Kayıt Defterinden dizin adıyla eşleştiği sürece, tüm zincir bilgileri otomatik olarak sağlanacaktır. Alternatif olarak zincirler, tek başına `networks.json`'da _desteklenebilir_, ancak bu belgelenmiş bir özellik değildir.
+'networks.json' dosyası, REStake'de 'desteklendiği' gibi hangi zincirlerin göründüğünü tanımlar; zincir adı Zincir Kayıt Defterinden dizin adıyla eşleştiği sürece, tüm zincir bilgileri otomatik olarak sağlanacaktır. Alternatif olarak zincirler, tek başına `networks.json`'da *desteklenebilir*, ancak bu belgelenmiş bir özellik değildir.
 
 Bir zinciri yeniden eklemek veya geçersiz kılmak için gerekli bilgileri aşağıdaki gibi `networks.json`'a ekleyin:
 


### PR DESCRIPTION
I verified that Ledger is able to send the necessary transactions to enable Authz. My editor auto formatted all the other changes per Markdownlint. They shouldn't have an observable impact on the Markdown files but I can revert if reviewers want a diff that just removes the bullet about the Ledger limitation.