### PR TITLE
Added prettyName detail to health.success/failed

### DIFF
--- a/src/autostake/index.mjs
+++ b/src/autostake/index.mjs
@@ -49,9 +49,9 @@ export default function Autostake(mnemonic, opts) {
           })
         }
         if (success || skipped) {
-          return health.success('Autostake finished')
+          return health.success('Autostake finished for ${data.prettyName}')
         } else {
-          return health.failed('Autostake failed')
+          return health.failed('Autostake failed for ${data.prettyName}')
         }
       }
     })


### PR DESCRIPTION
Added prettyName to "Autostake finised/failed" log.
Useful for analyzing output/result via scripts and external tools