### PR TITLE
Updated gas_price on networks.json for sentinel chain

### DIFF
--- a/src/networks.json
+++ b/src/networks.json
@@ -54,7 +54,7 @@
   },
   {
     "name": "sentinel",
-    "gasPrice": "0.02udvpn"
+    "gasPrice": "0.1udvpn"
   },
   {
     "name": "dig",


### PR DESCRIPTION
With the old gas price for sentinel chain restake was not working anymore. I put 0.1udvpn and it works fine