### PR TITLE
Fix url path building

### DIFF
--- a/src/utils/QueryClient.mjs
+++ b/src/utils/QueryClient.mjs
@@ -253,13 +253,16 @@ const QueryClient = async (chainId, restUrls, opts) => {
   }
 
   function apiUrl(type, path){
-    return restUrl + apiPath(type, path)
+    const normalizedRestUrl = restUrl.replace(/\/$/, '')
+    return normalizedRestUrl + apiPath(type, path)
   }
 
   function apiPath(type, path){
     const versions = config.apiVersions || {}
     const version = versions[type] || 'v1beta1'
-    return `/cosmos/${type}/${version}/${path}`
+    const normalizedType = type.replace(/^\/+/, '')
+    const normalizedPath = path.replace(/^\/+/, '')
+    return `/cosmos/${normalizedType}/${version}/${normalizedPath}`
   }
 
   return {

--- a/src/utils/QueryClient.mjs
+++ b/src/utils/QueryClient.mjs
@@ -225,7 +225,7 @@ const QueryClient = async (chainId, restUrls, opts) => {
         urls = [urls]
       }
     }
-    const path = type === "rest" ? apiPath('/base/tendermint', 'blocks/latest') : "/block";
+    const path = type === "rest" ? apiPath('base/tendermint', 'blocks/latest') : "/block";
     return Promise.any(urls.map(async (url) => {
       url = url.replace(/\/$/, '')
       try {


### PR DESCRIPTION
This is fairly overkill, but the "actual" bug is the trailing `/` before `base` which resulted in:

```
"GET https://rest.lavenderfive.com/akash/cosmos//base/tendermint/v1beta1/blocks/latest HTTP/2.0"
```

(note the extra `/`, which resulted in an error and therefore restake failed).

The `apiUrl` and `apiPath` changes are "insurance" in case a trailing slash happens again it's stripped out.