### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,20 @@
-# dev env
-FROM node:20.15-buster
+FROM node:20-bookworm
 
-RUN apt-get update && apt-get install -y python3 make g++
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends python3 build-essential \
+ && rm -rf /var/lib/apt/lists/*
 
 ENV NODE_ENV=development
 
 WORKDIR /usr/src/app
+
 COPY package*.json ./
-RUN npm install
-COPY . ./
+RUN npm ci || npm install
+COPY . .
 
 ENV DIRECTORY_PROTOCOL=https
 ENV DIRECTORY_DOMAIN=cosmos.directory
 
 EXPOSE 3000
-CMD npm run autostake
+
+CMD ["npm", "run", "autostake"]


### PR DESCRIPTION
#808 Updated Dockerfile to use node:20-bookworm instead of EOL buster, fix apt-get errors, install deps, and clean up apt cache for smaller image